### PR TITLE
chore: Remove CodeQL strategy

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,9 +10,6 @@ on:
 jobs:
   CodeQL-Build:
 
-    strategy:
-      fail-fast: false
-
     # CodeQL runs on ubuntu-latest and windows-latest
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
The job isn't using a matrix, so this value isn't allowed