### PR TITLE
Fix connection errors if a retry is encountered

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -4005,8 +4005,13 @@ function run() {
                 const options = {
                     continueOnError: false
                 };
-                yield artifactClient.uploadArtifact(name || constants_1.getDefaultArtifactName(), searchResult.filesToUpload, searchResult.rootDirectory, options);
-                core.info('Artifact upload has finished successfully!');
+                const uploadResponse = yield artifactClient.uploadArtifact(name || constants_1.getDefaultArtifactName(), searchResult.filesToUpload, searchResult.rootDirectory, options);
+                if (uploadResponse.failedItems.length > 0) {
+                    core.setFailed(`An error was encountered when uploading ${uploadResponse.artifactName}. There were ${uploadResponse.failedItems.length} items that failed to upload.`);
+                }
+                else {
+                    core.info(`Artifact ${uploadResponse.artifactName} has been successfully uploaded!`);
+                }
             }
         }
         catch (err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "upload-artifact",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@actions/artifact": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-0.3.1.tgz",
-      "integrity": "sha512-czRvOioOpuvmF/qDevfVVpZeBt7pjYlrnmM1+tRuCpKJxjWFYgi5MIW7TfscyupXPvtJz9jIxMjvxy9Eug1QEA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-0.3.2.tgz",
+      "integrity": "sha512-KzUe5DEeVXprAodxfGKtx9f7ukuVKE6V6pge6t5GDGk0cdkfiMEfahoq7HfBsOsmVy4J7rr1YZQPUTvXveYinw==",
       "dev": true,
       "requires": {
         "@actions/core": "^1.2.1",
@@ -6520,9 +6520,9 @@
       }
     },
     "tmp-promise": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-2.0.2.tgz",
-      "integrity": "sha512-zl71nFWjPKW2KXs+73gEk8RmqvtAeXPxhWDkTUoa3MSMkjq3I+9OeknjF178MQoMYsdqL730hfzvNfEkePxq9Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-2.1.1.tgz",
+      "integrity": "sha512-Z048AOz/w9b6lCbJUpevIJpRpUztENl8zdv1bmAKVHimfqRFl92ROkmT9rp7TVBnrEw2gtMTol/2Cp2S2kJa4Q==",
       "dev": true,
       "requires": {
         "tmp": "0.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upload-artifact",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Upload a build artifact that can be used by subsequent workflow steps",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/actions/upload-artifact#readme",
   "devDependencies": {
-    "@actions/artifact": "^0.3.1",
+    "@actions/artifact": "^0.3.2",
     "@actions/core": "^1.2.3",
     "@actions/glob": "^0.1.0",
     "@actions/io": "^1.0.2",

--- a/src/upload-artifact.ts
+++ b/src/upload-artifact.ts
@@ -23,14 +23,22 @@ async function run(): Promise<void> {
       const options: UploadOptions = {
         continueOnError: false
       }
-      await artifactClient.uploadArtifact(
+      const uploadResponse = await artifactClient.uploadArtifact(
         name || getDefaultArtifactName(),
         searchResult.filesToUpload,
         searchResult.rootDirectory,
         options
       )
 
-      core.info('Artifact upload has finished successfully!')
+      if (uploadResponse.failedItems.length > 0) {
+        core.setFailed(
+          `An error was encountered when uploading ${uploadResponse.artifactName}. There were ${uploadResponse.failedItems.length} items that failed to upload.`
+        )
+      } else {
+        core.info(
+          `Artifact ${uploadResponse.artifactName} has been successfully uploaded!`
+        )
+      }
     }
   } catch (err) {
     core.setFailed(err.message)

--- a/src/upload-artifact.ts
+++ b/src/upload-artifact.ts
@@ -21,7 +21,7 @@ async function run(): Promise<void> {
 
       const artifactClient = create()
       const options: UploadOptions = {
-        continueOnError: true
+        continueOnError: false
       }
       await artifactClient.uploadArtifact(
         name || getDefaultArtifactName(),


### PR DESCRIPTION
## Overview

Fixes: https://github.com/actions/upload-artifact/issues/71

- The `@actions/artifact` npm package from `actions/toolkit` was updated to `0.3.2`. With the new release, there was a fix for `readstreams` not correctly being reset if an error is encountered. This was addressed in the following PR: https://github.com/actions/toolkit/pull/458
- Also, setting `continueOnError` to `false` so that if there are any more errors, the artifact upload stops completely and users won't have have to click on their runs to see if there was a failure
    - https://github.com/actions/upload-artifact/issues/71#issuecomment-621875007
    - https://github.com/actions/upload-artifact/issues/71#issuecomment-628223703 

## Testing

This is a relatively low risk change, considering the same bug was fixed in `@actions/cache`: https://github.com/actions/cache/pull/305

Stress test uploading 9000+ small files and 1 large file: https://github.com/konradpabjan/artifact-test/runs/679266178?check_suite_focus=true