### PR TITLE
Remove directory symlinks before starting upload

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6225,6 +6225,8 @@ const path = __importStar(__webpack_require__(622));
 const core_1 = __webpack_require__(470);
 const fs_1 = __webpack_require__(747);
 const path_1 = __webpack_require__(622);
+const util_1 = __webpack_require__(669);
+const stats = util_1.promisify(fs_1.stat);
 function getDefaultGlobOptions() {
     return {
         followSymbolicLinks: true,
@@ -6293,7 +6295,9 @@ function findFilesToUpload(searchPath, globOptions) {
           directories so filter any directories out from the raw search results
         */
         for (const searchResult of rawSearchResults) {
-            if (!fs_1.lstatSync(searchResult).isDirectory()) {
+            const fileStats = yield stats(searchResult);
+            // isDirectory() returns false for symlinks if using fs.lstat(), make sure to use fs.stat() instead
+            if (!fileStats.isDirectory()) {
                 core_1.debug(`File:${searchResult} was found using the provided searchPath`);
                 searchResults.push(searchResult);
             }


### PR DESCRIPTION
## Overview

Resolves https://github.com/actions/upload-artifact/issues/76

The root cause was that `fs.lstat` was used instead of `fs.stat`. Certain paths should have been omitted from the list of files to upload and this ensures directories correctly get identified before an upload begins.

- What is the difference between the two? https://stackoverflow.com/questions/32478698/what-is-the-different-between-stat-fstat-and-lstat-functions-in-node-js
- Some more information: https://github.com/nodejs/node/issues/25342
- Even more info: https://github.com/actions/toolkit/blob/ccad19055eadcd85dd8bf73a487385c9c7233b4e/packages/glob/src/internal-globber.ts#L218

`fs.lstat` will always return false when `isDirectory` is called if the filePath is a symbolic link. This can cause problems down the line when `fs.createReadStream` is called inside `@actions/artifact` during upload.


## Testing
https://github.com/konradpabjan/macos-eisdir/runs/914682769?check_suite_focus=true

I used a minimal repo that a user created as part of #76  
In a earlier failed run, you can see that the problematic file is a symlink: https://github.com/konradpabjan/macos-eisdir/runs/914415784?check_suite_focus=true#step:5:81

With the symlink present i first tried `lstat()` then `realPath()` and then `isDirectory()` before that is able to correctly say if that is a directory. A single call with `stat()` will correctly determine if the path is a directory. In addition, even with the full real path, I tried doing `fs.createReadStream` and that would fail with the same `EISDIR` error so the symlink/directory should never be uploaded to begin with 

