### PR TITLE
Add new option to specify behavior if no files found

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ If a path (or paths), result in no files being found for the artifact, the actio
   with:
     name: my-artifact
     path: path/to/artifact/
-    if-no-files-found: error # 'warn' or 'suppress' are also available, defaults to `warn` 
+    if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn` 
 ```
 
 ### Conditional Artifact Upload

--- a/README.md
+++ b/README.md
@@ -88,6 +88,18 @@ Relative and absolute file paths are both allowed. Relative paths are rooted aga
 
 The [@actions/artifact](https://github.com/actions/toolkit/tree/main/packages/artifact) package is used internally to handle most of the logic around uploading an artifact. There is extra documentation around upload limitations and behavior in the toolkit repo that is worth checking out.
 
+### Customization if no files are found
+
+If a path (or paths), result in no files being found for the artifact, the action will succeed but print out a warning. In certain scenarios it may be desirable to fail the action or suppress the warning. The `if-no-files-found` option allows you to customize the behavior of the action if no files are found.
+
+```yaml
+- uses: actions/upload-artifact@v2
+  with:
+    name: my-artifact
+    path: path/to/artifact/
+    if-no-files-found: error # 'warn' or 'suppress' are also available, defaults to `warn` 
+```
+
 ### Conditional Artifact Upload
 
 To upload artifacts only when the previous step of a job failed, use [`if: failure()`](https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions#job-status-check-functions):

--- a/action.yml
+++ b/action.yml
@@ -4,10 +4,19 @@ author: 'GitHub'
 inputs: 
   name:
     description: 'Artifact name'
-    required: false
+    default: 'artifact'
   path:
     description: 'A file, directory or wildcard pattern that describes what to upload'
     required: true
+  if-no-files-found:
+    description: >
+      The desired behavior if no files are found using the provided path.
+
+      Available Options:
+        warn: Output a warning but do not fail the action
+        error: Fail the action with an error message
+        suppress: Do not output any warnings or errors, the action does not fail
+    default: 'warn'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
       Available Options:
         warn: Output a warning but do not fail the action
         error: Fail the action with an error message
-        suppress: Do not output any warnings or errors, the action does not fail
+        ignore: Do not output any warnings or errors, the action does not fail
     default: 'warn'
 runs:
   using: 'node12'

--- a/dist/index.js
+++ b/dist/index.js
@@ -6375,7 +6375,7 @@ function getInputs() {
     const ifNoFilesFound = core.getInput(constants_1.Inputs.IfNoFilesFound);
     const noFileBehavior = constants_1.NoFileOptions[ifNoFilesFound];
     if (!noFileBehavior) {
-        core.setFailed(`Unrecognized if-no-files-found input. Provided ${ifNoFilesFound}. Available options include ${Object.keys(constants_1.NoFileOptions).map(k => constants_1.NoFileOptions[k])}`);
+        core.setFailed(`Unrecognized if-no-files-found input. Provided ${ifNoFilesFound}. Available options include ${Object.keys(constants_1.NoFileOptions)}`);
     }
     return {
         artifactName: name,
@@ -7307,15 +7307,15 @@ var NoFileOptions;
     /**
      * Default. Output a warning but do not fail the action
      */
-    NoFileOptions[NoFileOptions["warn"] = 0] = "warn";
+    NoFileOptions["warn"] = "warn";
     /**
      * Fail the action with an error message
      */
-    NoFileOptions[NoFileOptions["error"] = 1] = "error";
+    NoFileOptions["error"] = "error";
     /**
      * Do not output any warnings or errors, the action does not fail
      */
-    NoFileOptions[NoFileOptions["suppress"] = 2] = "suppress";
+    NoFileOptions["suppress"] = "suppress";
 })(NoFileOptions = exports.NoFileOptions || (exports.NoFileOptions = {}));
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -3997,7 +3997,6 @@ function run() {
             const searchResult = yield search_1.findFilesToUpload(inputs.searchPath);
             if (searchResult.filesToUpload.length === 0) {
                 // No files were found, different use cases warrant different types of behavior if nothing is found
-                console.log(inputs.ifNoFilesFound);
                 switch (inputs.ifNoFilesFound) {
                     case constants_1.NoFileOptions.warn: {
                         core.warning(`No files were found with the provided path: ${inputs.searchPath}. No artifacts will be uploaded.`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -6375,7 +6375,7 @@ function getInputs() {
     const ifNoFilesFound = core.getInput(constants_1.Inputs.IfNoFilesFound);
     const noFileBehavior = constants_1.NoFileOptions[ifNoFilesFound];
     if (!noFileBehavior) {
-        core.setFailed(`Unrecognized if-no-files-found input. Provided ${ifNoFilesFound}. Available options include ${Object.keys(constants_1.NoFileOptions)}`);
+        core.setFailed(`Unrecognized if-no-files-found input. Provided ${ifNoFilesFound}. Available options: ${Object.keys(constants_1.NoFileOptions)}`);
     }
     return {
         artifactName: name,

--- a/dist/index.js
+++ b/dist/index.js
@@ -4006,7 +4006,7 @@ function run() {
                         core.setFailed(`No files were found with the provided path: ${inputs.searchPath}. No artifacts will be uploaded.`);
                         break;
                     }
-                    case constants_1.NoFileOptions.suppress: {
+                    case constants_1.NoFileOptions.ignore: {
                         core.info(`No files were found with the provided path: ${inputs.searchPath}. No artifacts will be uploaded.`);
                         break;
                     }
@@ -7315,7 +7315,7 @@ var NoFileOptions;
     /**
      * Do not output any warnings or errors, the action does not fail
      */
-    NoFileOptions["suppress"] = "suppress";
+    NoFileOptions["ignore"] = "ignore";
 })(NoFileOptions = exports.NoFileOptions || (exports.NoFileOptions = {}));
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -6374,6 +6374,9 @@ function getInputs() {
     const path = core.getInput(constants_1.Inputs.Path, { required: true });
     const ifNoFilesFound = core.getInput(constants_1.Inputs.IfNoFilesFound);
     const noFileBehavior = constants_1.NoFileOptions[ifNoFilesFound];
+    if (!noFileBehavior) {
+        core.setFailed(`Unrecognized if-no-files-found input. Provided ${ifNoFilesFound}. Available options include ${Object.keys(constants_1.NoFileOptions).map(k => constants_1.NoFileOptions[k])}`);
+    }
     return {
         artifactName: name,
         searchPath: path,

--- a/dist/index.js
+++ b/dist/index.js
@@ -6375,7 +6375,7 @@ function getInputs() {
     const ifNoFilesFound = core.getInput(constants_1.Inputs.IfNoFilesFound);
     const noFileBehavior = constants_1.NoFileOptions[ifNoFilesFound];
     if (!noFileBehavior) {
-        core.setFailed(`Unrecognized if-no-files-found input. Provided ${ifNoFilesFound}. Available options: ${Object.keys(constants_1.NoFileOptions)}`);
+        core.setFailed(`Unrecognized ${constants_1.Inputs.IfNoFilesFound} input. Provided: ${ifNoFilesFound}. Available options: ${Object.keys(constants_1.NoFileOptions)}`);
     }
     return {
         artifactName: name,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,8 +1,22 @@
 export enum Inputs {
   Name = 'name',
-  Path = 'path'
+  Path = 'path',
+  IfNoFilesFound = 'if-no-files-found'
 }
 
-export function getDefaultArtifactName(): string {
-  return 'artifact'
+export enum NoFileOptions {
+  /**
+   * Default. Output a warning but do not fail the action
+   */
+  warn,
+
+  /**
+   * Fail the action with an error message
+   */
+  error,
+
+  /**
+   * Do not output any warnings or errors, the action does not fail
+   */
+  suppress
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,15 +8,15 @@ export enum NoFileOptions {
   /**
    * Default. Output a warning but do not fail the action
    */
-  warn,
+  warn = 'warn',
 
   /**
    * Fail the action with an error message
    */
-  error,
+  error = 'error',
 
   /**
    * Do not output any warnings or errors, the action does not fail
    */
-  suppress
+  suppress = 'suppress'
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,5 +18,5 @@ export enum NoFileOptions {
   /**
    * Do not output any warnings or errors, the action does not fail
    */
-  suppress = 'suppress'
+  ignore = 'ignore'
 }

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -16,7 +16,7 @@ export function getInputs(): UploadInputs {
     core.setFailed(
       `Unrecognized if-no-files-found input. Provided ${ifNoFilesFound}. Available options include ${Object.keys(
         NoFileOptions
-      ).map(k => NoFileOptions[k as string])}`
+      )}`
     )
   }
 

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -12,6 +12,14 @@ export function getInputs(): UploadInputs {
   const ifNoFilesFound = core.getInput(Inputs.IfNoFilesFound)
   const noFileBehavior: NoFileOptions = NoFileOptions[ifNoFilesFound]
 
+  if (!noFileBehavior) {
+    core.setFailed(
+      `Unrecognized if-no-files-found input. Provided ${ifNoFilesFound}. Available options include ${Object.keys(
+        NoFileOptions
+      ).map(k => NoFileOptions[k as string])}`
+    )
+  }
+
   return {
     artifactName: name,
     searchPath: path,

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -14,7 +14,7 @@ export function getInputs(): UploadInputs {
 
   if (!noFileBehavior) {
     core.setFailed(
-      `Unrecognized if-no-files-found input. Provided ${ifNoFilesFound}. Available options include ${Object.keys(
+      `Unrecognized if-no-files-found input. Provided ${ifNoFilesFound}. Available options: ${Object.keys(
         NoFileOptions
       )}`
     )

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -1,0 +1,20 @@
+import * as core from '@actions/core'
+import {Inputs, NoFileOptions} from './constants'
+import {UploadInputs} from './upload-inputs'
+
+/**
+ * Helper to get all the inputs for the action
+ */
+export function getInputs(): UploadInputs {
+  const name = core.getInput(Inputs.Name)
+  const path = core.getInput(Inputs.Path, {required: true})
+
+  const ifNoFilesFound = core.getInput(Inputs.IfNoFilesFound)
+  const noFileBehavior: NoFileOptions = NoFileOptions[ifNoFilesFound]
+
+  return {
+    artifactName: name,
+    searchPath: path,
+    ifNoFilesFound: noFileBehavior
+  }
+}

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -14,7 +14,9 @@ export function getInputs(): UploadInputs {
 
   if (!noFileBehavior) {
     core.setFailed(
-      `Unrecognized if-no-files-found input. Provided ${ifNoFilesFound}. Available options: ${Object.keys(
+      `Unrecognized ${
+        Inputs.IfNoFilesFound
+      } input. Provided: ${ifNoFilesFound}. Available options: ${Object.keys(
         NoFileOptions
       )}`
     )

--- a/src/upload-artifact.ts
+++ b/src/upload-artifact.ts
@@ -1,21 +1,38 @@
 import * as core from '@actions/core'
 import {create, UploadOptions} from '@actions/artifact'
-import {Inputs, getDefaultArtifactName} from './constants'
 import {findFilesToUpload} from './search'
+import {getInputs} from './input-helper'
+import {NoFileOptions} from './constants'
 
 async function run(): Promise<void> {
   try {
-    const name = core.getInput(Inputs.Name, {required: false})
-    const path = core.getInput(Inputs.Path, {required: true})
-
-    const searchResult = await findFilesToUpload(path)
+    const inputs = getInputs()
+    const searchResult = await findFilesToUpload(inputs.searchPath)
     if (searchResult.filesToUpload.length === 0) {
-      core.warning(
-        `No files were found for the provided path: ${path}. No artifacts will be uploaded.`
-      )
+      // No files were found, different use cases warrant different types of behavior if nothing is found
+      switch (inputs.ifNoFilesFound) {
+        case NoFileOptions.warn: {
+          core.warning(
+            `No files were found with the provided path: ${inputs.searchPath}. No artifacts will be uploaded.`
+          )
+          break
+        }
+        case NoFileOptions.error: {
+          core.setFailed(
+            `No files were found with the provided path: ${inputs.searchPath}. No artifacts will be uploaded.`
+          )
+          break
+        }
+        case NoFileOptions.suppress: {
+          core.info(
+            `No files were found with the provided path: ${inputs.searchPath}. No artifacts will be uploaded.`
+          )
+          break
+        }
+      }
     } else {
       core.info(
-        `With the provided path, there will be ${searchResult.filesToUpload.length} files uploaded`
+        `With the provided path, there will be ${searchResult.filesToUpload.length} file(s) uploaded`
       )
       core.debug(`Root artifact directory is ${searchResult.rootDirectory}`)
 
@@ -24,7 +41,7 @@ async function run(): Promise<void> {
         continueOnError: false
       }
       const uploadResponse = await artifactClient.uploadArtifact(
-        name || getDefaultArtifactName(),
+        inputs.artifactName,
         searchResult.filesToUpload,
         searchResult.rootDirectory,
         options

--- a/src/upload-artifact.ts
+++ b/src/upload-artifact.ts
@@ -10,7 +10,6 @@ async function run(): Promise<void> {
     const searchResult = await findFilesToUpload(inputs.searchPath)
     if (searchResult.filesToUpload.length === 0) {
       // No files were found, different use cases warrant different types of behavior if nothing is found
-      console.log(inputs.ifNoFilesFound)
       switch (inputs.ifNoFilesFound) {
         case NoFileOptions.warn: {
           core.warning(

--- a/src/upload-artifact.ts
+++ b/src/upload-artifact.ts
@@ -10,6 +10,7 @@ async function run(): Promise<void> {
     const searchResult = await findFilesToUpload(inputs.searchPath)
     if (searchResult.filesToUpload.length === 0) {
       // No files were found, different use cases warrant different types of behavior if nothing is found
+      console.log(inputs.ifNoFilesFound)
       switch (inputs.ifNoFilesFound) {
         case NoFileOptions.warn: {
           core.warning(

--- a/src/upload-artifact.ts
+++ b/src/upload-artifact.ts
@@ -23,7 +23,7 @@ async function run(): Promise<void> {
           )
           break
         }
-        case NoFileOptions.suppress: {
+        case NoFileOptions.ignore: {
           core.info(
             `No files were found with the provided path: ${inputs.searchPath}. No artifacts will be uploaded.`
           )

--- a/src/upload-inputs.ts
+++ b/src/upload-inputs.ts
@@ -1,0 +1,18 @@
+import {NoFileOptions} from './constants'
+
+export interface UploadInputs {
+  /**
+   * The name of the artifact that will be uploaded
+   */
+  artifactName: string
+
+  /**
+   * The search path used to describe what to upload as part of the artifact
+   */
+  searchPath: string
+
+  /**
+   * The desired behavior if no files are found with the provided search path
+   */
+  ifNoFilesFound: NoFileOptions
+}


### PR DESCRIPTION
## Overview

Addresses #91 and #90 

By default, if no files are found with the provided `path` input, the `v2` version of `upload-artifact` with not fail and there will be a warning in the logs. 

There have been numerous requests for the action to fail or for no warning so I'm adding an extra input option that will allow users to control this. The new input is called `if-no-files-found` (not too sure about this name though, any ideas will be appreciated). The available options include `warn` (default), `error` and `ignore`. The default remains as `warn` since we don't want existing behavior to change.

`README` update: 🎨 [rendered](https://github.com/actions/upload-artifact/blob/konradpabjan/no-files-found/README.md#customization-if-no-files-are-found) 🖌

## Testing

### Upload with default behavior
https://github.com/konradpabjan/artifact-test/runs/918666195?check_suite_focus=true#step:4:23

![image](https://user-images.githubusercontent.com/16109154/88660563-41e08280-d0d7-11ea-9d52-c08cfdad6725.png)

### Upload with `warn`

https://github.com/konradpabjan/artifact-test/runs/918670916?check_suite_focus=true#step:4:23

![image](https://user-images.githubusercontent.com/16109154/88660726-97b52a80-d0d7-11ea-9838-cd72a944938e.png)

### Upload with `error`

https://github.com/konradpabjan/artifact-test/runs/918715964#step:4:23

![image](https://user-images.githubusercontent.com/16109154/88661989-a43a8280-d0d9-11ea-89ee-0a203d9848bc.png)

### Upload with `ignore`

https://github.com/konradpabjan/artifact-test/runs/924130458?check_suite_focus=true#step:4:23

![image](https://user-images.githubusercontent.com/16109154/88662302-101ceb00-d0da-11ea-9fc0-7a5c0478870f.png)

### Upload with an option that is not available

https://github.com/konradpabjan/artifact-test/runs/918907180#step:4:15

![image](https://user-images.githubusercontent.com/16109154/88667280-722d1e80-d0e1-11ea-882a-042d6fa7ee3e.png)

