### PR TITLE
Detect case insensitive uploads + Bump @actions/artifact to version 0.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,32 @@ Environment variables along with context expressions can also be used for input.
 In the top right corner of a workflow run, once the run is over, if you used this action, there will be a `Artifacts` dropdown which you can download items from. Here's a screenshot of what it looks like<br/>
 <img src="https://user-images.githubusercontent.com/16109154/72556687-20235a80-386d-11ea-9e2a-b534faa77083.png" width="375" height="140">
 
-There is a trashcan icon that can be used to delete the artifact. This icon will only appear for users who have write permissions to the repository. 
+There is a trashcan icon that can be used to delete the artifact. This icon will only appear for users who have write permissions to the repository.
+
+# Limitations
+
+### Permission Loss
+
+:exclamation: File permissions are not maintained during artifact upload :exclamation: For example, if you make a file executable using `chmod` and then upload that file, post-download the file is no longer guaranteed to be set as an executable.
+
+### Case Insensitive Uploads
+
+:exclamation: File uploads are case insensitive :exclamation: If you upload `A.txt` and `a.txt` with the same root path, only a single file will be saved and available during download.
+
+### Maintaining file permissions and case sensitive files
+
+If file permissions and case sensitivity are required, you can `tar` all of your files together before artifact upload. Post download, the `tar` file will maintain file permissions and case sensitivity.
+
+```yaml
+  - name: 'Tar files'
+    run: tar -cvf my_files.tar /path/to/my/directory
+
+  - name: 'Upload Artifact'
+    uses: actions/upload-artifact@v2
+    with:
+      name: my-artifact
+      path: my_files.tar    
+```
 
 ## Additional Documentation
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -6307,11 +6307,11 @@ function findFilesToUpload(searchPath, globOptions) {
                 core_1.debug(`File:${searchResult} was found using the provided searchPath`);
                 searchResults.push(searchResult);
                 // detect any files that would be overwritten because of case insensitivity
-                const currentSetSize = set.size;
-                set.add(searchResult.toLowerCase());
-                if (currentSetSize === set.size) {
-                    // set size has not changed which means paths can be overwritten
+                if (set.has(searchResult.toLowerCase())) {
                     core_1.info(`Uploads are case insensitive: ${searchResult} was detected that it will be overwritten by another file with the same path`);
+                }
+                else {
+                    set.add(searchResult.toLowerCase());
                 }
             }
             else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@actions/artifact": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-0.3.2.tgz",
-      "integrity": "sha512-KzUe5DEeVXprAodxfGKtx9f7ukuVKE6V6pge6t5GDGk0cdkfiMEfahoq7HfBsOsmVy4J7rr1YZQPUTvXveYinw==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-0.3.3.tgz",
+      "integrity": "sha512-sKC1uA5p6064C6Qypmmt6O8iKlpDyMTfqqDlS4/zfJX1Hs8NbbzPLLN81RpewuJPWQNnroeF52w4VCWypbSNaA==",
       "dev": true,
       "requires": {
         "@actions/core": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/actions/upload-artifact#readme",
   "devDependencies": {
-    "@actions/artifact": "^0.3.2",
+    "@actions/artifact": "^0.3.3",
     "@actions/core": "^1.2.3",
     "@actions/glob": "^0.1.0",
     "@actions/io": "^1.0.2",

--- a/src/search.ts
+++ b/src/search.ts
@@ -107,13 +107,12 @@ export async function findFilesToUpload(
       searchResults.push(searchResult)
 
       // detect any files that would be overwritten because of case insensitivity
-      const currentSetSize = set.size
-      set.add(searchResult.toLowerCase())
-      if (currentSetSize === set.size) {
-        // set size has not changed which means paths can be overwritten
+      if (set.has(searchResult.toLowerCase())) {
         info(
           `Uploads are case insensitive: ${searchResult} was detected that it will be overwritten by another file with the same path`
         )
+      } else {
+        set.add(searchResult.toLowerCase())
       }
     } else {
       debug(

--- a/src/search.ts
+++ b/src/search.ts
@@ -66,7 +66,7 @@ function getMultiPathLCA(searchPaths: string[]): string {
     return true
   }
 
-  // Loop over all the search paths until there is a non-common ancestor or we go out of bounds
+  // loop over all the search paths until there is a non-common ancestor or we go out of bounds
   while (splitIndex < smallestPathLength) {
     if (!isPathTheSame()) {
       break
@@ -90,6 +90,12 @@ export async function findFilesToUpload(
   const rawSearchResults: string[] = await globber.glob()
 
   /*
+    Files are saved with case insensitivity. Uploading both a.txt and A.txt will files to be overwritten
+    Detect any files that could be overwritten for user awareness
+  */
+  const set = new Set<string>()
+
+  /*
     Directories will be rejected if attempted to be uploaded. This includes just empty
     directories so filter any directories out from the raw search results
   */
@@ -99,6 +105,16 @@ export async function findFilesToUpload(
     if (!fileStats.isDirectory()) {
       debug(`File:${searchResult} was found using the provided searchPath`)
       searchResults.push(searchResult)
+
+      // detect any files that would be overwritten because of case insensitivity
+      const currentSetSize = set.size
+      set.add(searchResult.toLowerCase())
+      if (currentSetSize === set.size) {
+        // set size has not changed which means paths can be overwritten
+        info(
+          `Uploads are case insensitive: ${searchResult} was detected that it will be overwritten by another file with the same path`
+        )
+      }
     } else {
       debug(
         `Removing ${searchResult} from rawSearchResults because it is a directory`


### PR DESCRIPTION
## Overview

- Bump `@actions/artifact` to version `0.3.3`
   - Updated user-agents strings for better internal telemetry
   - Increase upload chunk size from 4MB to 8MB
- Case Insensitivity
   - Document behavior in `README`
   - Detect when files would be overwritten and a log a standard `info` message
- File Permissions
   - Document behavior in `README`

## Testing

https://github.com/konradpabjan/artifact-test/runs/932322104?check_suite_focus=true#step:3:22

![image](https://user-images.githubusercontent.com/16109154/89054205-ba09ab00-d358-11ea-8548-6ccf36d558da.png)