### PR TITLE
Add an option to specify retention period for artifacts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,12 @@ inputs:
         error: Fail the action with an error message
         ignore: Do not output any warnings or errors, the action does not fail
     default: 'warn'
+  retention-days:
+    description: >
+      Duration after which artifact will expire in days. 0 means using default retention.
+
+      Minimum 1 day.
+      Maximum 90 days unless changed from the repository settings page.
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -6405,6 +6405,9 @@ function getInputs() {
     const retentionDaysStr = core.getInput(constants_1.Inputs.RetentionDays);
     if (retentionDaysStr) {
         inputs.retentionDays = parseInt(retentionDaysStr);
+        if (isNaN(inputs.retentionDays)) {
+            core.setFailed('Invalid retention-days');
+        }
     }
     return inputs;
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -3767,7 +3767,7 @@ class DefaultArtifactClient {
             }
             else {
                 // Create an entry for the artifact in the file container
-                const response = yield uploadHttpClient.createArtifactInFileContainer(name);
+                const response = yield uploadHttpClient.createArtifactInFileContainer(name, options);
                 if (!response.fileContainerResourceUrl) {
                     core.debug(response.toString());
                     throw new Error('No URL provided by the Artifact Service to upload an artifact to');
@@ -4019,6 +4019,9 @@ function run() {
                 const options = {
                     continueOnError: false
                 };
+                if (inputs.retentionDays) {
+                    options.retentionDays = inputs.retentionDays;
+                }
                 const uploadResponse = yield artifactClient.uploadArtifact(inputs.artifactName, searchResult.filesToUpload, searchResult.rootDirectory, options);
                 if (uploadResponse.failedItems.length > 0) {
                     core.setFailed(`An error was encountered when uploading ${uploadResponse.artifactName}. There were ${uploadResponse.failedItems.length} items that failed to upload.`);
@@ -4108,6 +4111,10 @@ function getWorkSpaceDirectory() {
     return workspaceDirectory;
 }
 exports.getWorkSpaceDirectory = getWorkSpaceDirectory;
+function getRetentionDays() {
+    return process.env['GITHUB_RETENTION_DAYS'];
+}
+exports.getRetentionDays = getRetentionDays;
 //# sourceMappingURL=config-variables.js.map
 
 /***/ }),
@@ -6390,11 +6397,16 @@ function getInputs() {
     if (!noFileBehavior) {
         core.setFailed(`Unrecognized ${constants_1.Inputs.IfNoFilesFound} input. Provided: ${ifNoFilesFound}. Available options: ${Object.keys(constants_1.NoFileOptions)}`);
     }
-    return {
+    const inputs = {
         artifactName: name,
         searchPath: path,
         ifNoFilesFound: noFileBehavior
     };
+    const retentionDaysStr = core.getInput(constants_1.Inputs.RetentionDays);
+    if (retentionDaysStr) {
+        inputs.retentionDays = parseInt(retentionDaysStr);
+    }
+    return inputs;
 }
 exports.getInputs = getInputs;
 
@@ -6666,12 +6678,17 @@ class UploadHttpClient {
      * @param {string} artifactName Name of the artifact being created
      * @returns The response from the Artifact Service if the file container was successfully created
      */
-    createArtifactInFileContainer(artifactName) {
+    createArtifactInFileContainer(artifactName, options) {
         return __awaiter(this, void 0, void 0, function* () {
             const parameters = {
                 Type: 'actions_storage',
                 Name: artifactName
             };
+            // calculate retention period
+            if (options && options.retentionDays) {
+                const maxRetentionStr = config_variables_1.getRetentionDays();
+                parameters.RetentionDays = utils_1.getProperRetention(options.retentionDays, maxRetentionStr);
+            }
             const data = JSON.stringify(parameters, null, 2);
             const artifactUrl = utils_1.getArtifactUrl();
             // use the first client from the httpManager, `keep-alive` is not used so the connection will close immediately
@@ -7314,6 +7331,7 @@ var Inputs;
     Inputs["Name"] = "name";
     Inputs["Path"] = "path";
     Inputs["IfNoFilesFound"] = "if-no-files-found";
+    Inputs["RetentionDays"] = "retention-days";
 })(Inputs = exports.Inputs || (exports.Inputs = {}));
 var NoFileOptions;
 (function (NoFileOptions) {
@@ -8137,6 +8155,21 @@ function createEmptyFilesForArtifact(emptyFilesToCreate) {
     });
 }
 exports.createEmptyFilesForArtifact = createEmptyFilesForArtifact;
+function getProperRetention(retentionInput, retentionSetting) {
+    if (retentionInput < 0) {
+        throw new Error('Invalid retention, minimum value is 1.');
+    }
+    let retention = retentionInput;
+    if (retentionSetting) {
+        const maxRetention = parseInt(retentionSetting);
+        if (!isNaN(maxRetention) && maxRetention < retention) {
+            core_1.warning(`Retention days is greater than the max value allowed by the repository setting, reduce retention to ${maxRetention} days`);
+            retention = maxRetention;
+        }
+    }
+    return retention;
+}
+exports.getProperRetention = getProperRetention;
 //# sourceMappingURL=utils.js.map
 
 /***/ }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@actions/artifact": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-0.3.5.tgz",
-      "integrity": "sha512-y27pBEnUjOqCP2zUf86YkiqGOp1r0C9zUOmGmcxizsHMls0wvk+FJwd+l8JIoukvj1BeBHYP+c+9AEqOt5AqMA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-0.4.0.tgz",
+      "integrity": "sha512-iPDMvCIogq22F3r11xyBbH2wtUuJYfa3llGM8Kxilx6lVrcGpWa5Bnb1ukD/MEmCn9SBXdz6eqNLa10GQ20HNg==",
       "dev": true,
       "requires": {
         "@actions/core": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/actions/upload-artifact#readme",
   "devDependencies": {
-    "@actions/artifact": "^0.3.5",
+    "@actions/artifact": "^0.4.0",
     "@actions/core": "^1.2.3",
     "@actions/glob": "^0.1.0",
     "@actions/io": "^1.0.2",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,8 @@
 export enum Inputs {
   Name = 'name',
   Path = 'path',
-  IfNoFilesFound = 'if-no-files-found'
+  IfNoFilesFound = 'if-no-files-found',
+  RetentionDays = 'retention-days'
 }
 
 export enum NoFileOptions {

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -31,6 +31,9 @@ export function getInputs(): UploadInputs {
   const retentionDaysStr = core.getInput(Inputs.RetentionDays)
   if (retentionDaysStr) {
     inputs.retentionDays = parseInt(retentionDaysStr)
+    if (isNaN(inputs.retentionDays)) {
+      core.setFailed('Invalid retention-days')
+    }
   }
 
   return inputs

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -22,9 +22,16 @@ export function getInputs(): UploadInputs {
     )
   }
 
-  return {
+  const inputs = {
     artifactName: name,
     searchPath: path,
     ifNoFilesFound: noFileBehavior
+  } as UploadInputs
+
+  const retentionDaysStr = core.getInput(Inputs.RetentionDays)
+  if (retentionDaysStr) {
+    inputs.retentionDays = parseInt(retentionDaysStr)
   }
+
+  return inputs
 }

--- a/src/upload-artifact.ts
+++ b/src/upload-artifact.ts
@@ -40,6 +40,10 @@ async function run(): Promise<void> {
       const options: UploadOptions = {
         continueOnError: false
       }
+      if (inputs.retentionDays) {
+        options.retentionDays = inputs.retentionDays
+      }
+
       const uploadResponse = await artifactClient.uploadArtifact(
         inputs.artifactName,
         searchResult.filesToUpload,

--- a/src/upload-inputs.ts
+++ b/src/upload-inputs.ts
@@ -15,4 +15,9 @@ export interface UploadInputs {
    * The desired behavior if no files are found with the provided search path
    */
   ifNoFilesFound: NoFileOptions
+
+  /**
+   * Duration after which artifact will expire in days
+   */
+  retentionDays: number
 }


### PR DESCRIPTION
#49
#34


Add an option to specify a shorter retention for each artifact:
```
      - uses: actions/upload-artifact
        with:
          name: my-artifact
          path: ./my_path
          retention-days: 30
```

If the new `retention-days` option is omitted or if the input is 0, the artifact will have a default retention of 90 days unless the value is overridden on the repository settings page (*coming later*).  This yaml input cannot be greater than the value specified on the setting page.  

Negative values are not allowed, so the artifact will live for 1 day at least.