### PR TITLE
Add support for uploading multiple artifacts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,11 @@ inputs:
   path:
     description: 'A file, directory or wildcard pattern that describes what to upload'
     required: true
+  single-archive:
+    description: >
+      Whether or not all files for the action should be combined into a single archive
+      or uploaded as separate archives
+    default: 'true'
   if-no-files-found:
     description: >
       The desired behavior if no files are found using the provided path.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
 export enum Inputs {
   Name = 'name',
   Path = 'path',
+  SingleArchive = 'single-archive',
   IfNoFilesFound = 'if-no-files-found',
   RetentionDays = 'retention-days'
 }

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -11,6 +11,7 @@ export function getInputs(): UploadInputs {
 
   const ifNoFilesFound = core.getInput(Inputs.IfNoFilesFound)
   const noFileBehavior: NoFileOptions = NoFileOptions[ifNoFilesFound]
+  const single = core.getInput(Inputs.SingleArchive) || 'true'
 
   if (!noFileBehavior) {
     core.setFailed(
@@ -22,9 +23,16 @@ export function getInputs(): UploadInputs {
     )
   }
 
+  if (single !== 'true' && single !== 'false') {
+    core.setFailed(
+      `Unrecognized ${Inputs.SingleArchive} input. Provided: ${single}. Must be 'true' or 'false'.`
+    )
+  }
+
   const inputs = {
     artifactName: name,
     searchPath: path,
+    singleArchive: single,
     ifNoFilesFound: noFileBehavior
   } as UploadInputs
 

--- a/src/upload-artifact.ts
+++ b/src/upload-artifact.ts
@@ -8,6 +8,7 @@ async function run(): Promise<void> {
   try {
     const inputs = getInputs()
     const searchResult = await findFilesToUpload(inputs.searchPath)
+
     if (searchResult.filesToUpload.length === 0) {
       // No files were found, different use cases warrant different types of behavior if nothing is found
       switch (inputs.ifNoFilesFound) {
@@ -44,21 +45,50 @@ async function run(): Promise<void> {
         options.retentionDays = inputs.retentionDays
       }
 
-      const uploadResponse = await artifactClient.uploadArtifact(
-        inputs.artifactName,
-        searchResult.filesToUpload,
-        searchResult.rootDirectory,
-        options
-      )
+      if (inputs.singleArchive === 'false') {
+        core.info(`Uploading artifacts as individual archives`)
 
-      if (uploadResponse.failedItems.length > 0) {
-        core.setFailed(
-          `An error was encountered when uploading ${uploadResponse.artifactName}. There were ${uploadResponse.failedItems.length} items that failed to upload.`
-        )
+        for (const fileToUpload of searchResult.filesToUpload) {
+          const uploadName = inputs.artifactName.concat(
+            '_'.concat(
+              fileToUpload.substring(fileToUpload.lastIndexOf('/') + 1)
+            )
+          )
+          core.info(
+            `Attempting to upload artifact with name: ${uploadName} at path ${fileToUpload}`
+          )
+          const uploadResponse = await artifactClient.uploadArtifact(
+            uploadName,
+            [fileToUpload],
+            searchResult.rootDirectory,
+            options
+          )
+
+          if (uploadResponse.failedItems.length > 0) {
+            core.setFailed(
+              `An error was encountered when uploading ${uploadName}. There were ${uploadResponse.failedItems.length} items that failed to upload.`
+            )
+          } else {
+            core.info(`Artifact ${uploadName} has been successfully uploaded!`)
+          }
+        }
       } else {
-        core.info(
-          `Artifact ${uploadResponse.artifactName} has been successfully uploaded!`
+        const uploadResponse = await artifactClient.uploadArtifact(
+          inputs.artifactName,
+          searchResult.filesToUpload,
+          searchResult.rootDirectory,
+          options
         )
+
+        if (uploadResponse.failedItems.length > 0) {
+          core.setFailed(
+            `An error was encountered when uploading ${uploadResponse.artifactName}. There were ${uploadResponse.failedItems.length} items that failed to upload.`
+          )
+        } else {
+          core.info(
+            `Artifact ${uploadResponse.artifactName} has been successfully uploaded!`
+          )
+        }
       }
     }
   } catch (err) {

--- a/src/upload-inputs.ts
+++ b/src/upload-inputs.ts
@@ -12,6 +12,11 @@ export interface UploadInputs {
   searchPath: string
 
   /**
+   * Whether or not to upload artifacts as a single archive or as individual files
+   */
+  singleArchive: string
+
+  /**
    * The desired behavior if no files are found with the provided search path
    */
   ifNoFilesFound: NoFileOptions


### PR DESCRIPTION
Closes #125 

## Summary:

Adds a new optional option to upload artifacts individually instead of all in one. Default behavior remains unchanged. To specify the new behavior, the config looks like:

```
    - name: Upload individual zips
      uses: actions/upload-artifact@vWhatever
      with:
        name: dummy
        path: dummy/*.zip
        single-archive: "false"
```

## Motivation:

In my github actions pipeline we run a series of test projects in matrix jobs and then zip up relevant logs. Each matrix jobs runs 3-7 test projects. We would like to upload these logs only failures are detected in each project (so 3-7 zips per matrix job). Currently the 3-7 zips get added to a larger zip and then uploaded, but we would like to keep them separate so we don't need to download the larger zip to check for the project's logs we care about.

Disclaimer: I'm a Java developer and have never worked with Typescript before so I did my best to code this up properly.