### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @artifacts-actions


### PR DESCRIPTION
Adding `CODEOWNERS` for this repo.  We're doing this to track ownership of all repos in the `actions` org.

For info on how `CODEOWNERS` works, see the [blog post](https://github.blog/2017-07-06-introducing-code-owners/).