### PR TITLE
Replace "file(s)" with "file" or "files"

### DIFF
--- a/src/upload-artifact.ts
+++ b/src/upload-artifact.ts
@@ -31,8 +31,9 @@ async function run(): Promise<void> {
         }
       }
     } else {
+      const s = searchResult.filesToUpload.length === 1 ? '' : 's'
       core.info(
-        `With the provided path, there will be ${searchResult.filesToUpload.length} file(s) uploaded`
+        `With the provided path, there will be ${searchResult.filesToUpload.length} file${s} uploaded`
       )
       core.debug(`Root artifact directory is ${searchResult.rootDirectory}`)
 


### PR DESCRIPTION
Instead of:

> With the provided path, there will be 1 file(s) uploaded

Show either:

> With the provided path, there will be 1 file uploaded

Or:

> With the provided path, there will be 2 files uploaded

