### PR TITLE
Display a warning if user tries to upload over 10000 files

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -4078,6 +4078,9 @@ function run() {
                 const s = searchResult.filesToUpload.length === 1 ? '' : 's';
                 core.info(`With the provided path, there will be ${searchResult.filesToUpload.length} file${s} uploaded`);
                 core.debug(`Root artifact directory is ${searchResult.rootDirectory}`);
+                if (searchResult.filesToUpload.length > 10000) {
+                    core.warning(`There are over 10,000 files in this artifact, consider create an archive before upload to improve the upload performance.`);
+                }
                 const artifactClient = artifact_1.create();
                 const options = {
                     continueOnError: false

--- a/src/upload-artifact.ts
+++ b/src/upload-artifact.ts
@@ -37,6 +37,12 @@ async function run(): Promise<void> {
       )
       core.debug(`Root artifact directory is ${searchResult.rootDirectory}`)
 
+      if (searchResult.filesToUpload.length > 10000) {
+        core.warning(
+          `There are over 10,000 files in this artifact, consider create an archive before upload to improve the upload performance.`
+        )
+      }
+
       const artifactClient = create()
       const options: UploadOptions = {
         continueOnError: false


### PR DESCRIPTION
https://github.com/actions/upload-artifact/issues/172

Warn user if they are creating artifacts with many loose files.  It will be more performant if they create an archive and upload the archive instead.  