### PR TITLE
Avoid triggering push for Dependabot branches

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,6 +2,7 @@ name: "Code scanning - action"
 
 on:
   push:
+    branches-ignore: "dependabot/*"
   pull_request:
     paths-ignore:
       - '**.md'


### PR DESCRIPTION
The CodeQL run is failing for Dependabot ([example](https://github.com/actions/upload-artifact/runs/2558152274?check_suite_focus=true#step:3:52)):

>  Error: Workflows triggered by Dependabot on the "push" event run with read-only access. Uploading Code Scanning results requires write access. To use Code Scanning with Dependabot, please ensure you are using the "pull_request" event for this workflow and avoid triggering on the "push" event for Dependabot branches. See https://docs.github.com/en/code-security/secure-coding/configuring-code-scanning#scanning-on-push for more information on how to configure these events.

This is disabling the `push` trigger for Dependabot branches so they will trigger on `pull_request` instead.

Alternatively, we could just do `push:branches:main`, but I'm not sure if we still want to trigger on push for other branches.