### PR TITLE
Avoid triggering push for Dependabot branches (again)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,7 +2,7 @@ name: "Code scanning - action"
 
 on:
   push:
-    branches-ignore: "dependabot/*"
+    branches-ignore: "dependabot/**"
   pull_request:
     paths-ignore:
       - '**.md'


### PR DESCRIPTION
#222 didn't work.  Dependabot branch names look like `dependabot/npm_and_yarn/glob-parent-5.1.2`.  According to the [docs](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet), `*` does not match `/` and you need `**` for that.