### PR TITLE
Create check-dist.yml

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -30,7 +30,7 @@ jobs:
           node-version: 12.x
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Move the committed index.js file
         run: mv dist/index.js /tmp

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -24,6 +24,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+
+      - run: npm install
       - run: mv dist/index.js /tmp
       - run: npm run release
       - run: git diff --ignore-all-space dist/index.js /tmp/index.js

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -29,10 +29,14 @@ jobs:
         with:
           node-version: 12.x
 
-      - run: npm install
-      - run: mv dist/index.js /tmp
-      - run: npm run release
-      - run: git diff --ignore-all-space dist/index.js /tmp/index.js
+      - name: Install dependencies
+        run: npm install
+      - name: Move checked in index.js file to tmp directory
+        run: mv dist/index.js /tmp
+      - name: Create new index.js file
+        run: npm run release
+      - name: Compare expected vs actual index.js file
+        run: git diff --ignore-all-space dist/index.js /tmp/index.js
         id: diff
 
       # If index.js was different than expected, upload the expected version as an artifact

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -31,7 +31,7 @@ jobs:
 
       # If index.js was different than expected, upload the expected version as an artifact
       - uses: actions/upload-artifact@v2
-        if: steps.diff.conclusion == "failure"
+        if: ${{ steps.diff.conclusion == "failure" }}
         with:
           name: index.js
           path: dist/index.js

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -37,7 +37,7 @@ jobs:
 
       # If index.js was different than expected, upload the expected version as an artifact
       - uses: actions/upload-artifact@v2
-        if: ${{ steps.diff.conclusion == 'failure' }}
+        if: ${{ failure() && steps.diff.conclusion == 'failure' }}
         with:
           name: index.js
           path: dist/index.js

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -31,7 +31,7 @@ jobs:
 
       # If index.js was different than expected, upload the expected version as an artifact
       - uses: actions/upload-artifact@v2
-        if: ${{ steps.diff.conclusion == "failure" }}
+        if: ${{ steps.diff.conclusion == 'failure' }}
         with:
           name: index.js
           path: dist/index.js

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -31,11 +31,14 @@ jobs:
 
       - name: Install dependencies
         run: npm install
-      - name: Move checked in index.js file to tmp directory
+
+      - name: Move the committed index.js file
         run: mv dist/index.js /tmp
-      - name: Create new index.js file
+
+      - name: Rebuild the index.js file
         run: npm run release
-      - name: Compare expected vs actual index.js file
+
+      - name: Compare the expected and actual index.js files
         run: git diff --ignore-all-space dist/index.js /tmp/index.js
         id: diff
 

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -1,0 +1,37 @@
+# `dist/index.js` is a special file in Actions.
+# When you reference an action with `uses:` in a workflow,
+# `index.js` is the code that will run.
+# For our project, we generate this file through a build process
+# from other source files.
+# We need to make sure the checked-in `index.js` actually matches what we expect it to be.
+name: Check dist/
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+  workflow_dispatch:
+
+jobs:
+  check-dist:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: mv dist/index.js /tmp
+      - run: npm run release
+      - run: git diff --ignore-all-space dist/index.js /tmp/index.js
+        id: diff
+
+      # If index.js was different than expected, upload the expected version as an artifact
+      - uses: actions/upload-artifact@v2
+        if: steps.diff.conclusion == "failure"
+        with:
+          name: index.js
+          path: dist/index.js

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,8 @@ jobs:
       with:
         node-version: 12.x
 
-    - name: npm install
-      run: npm install
+    - name: Install dependencies
+      run: npm ci
 
     - name: Compile
       run: npm run build

--- a/dist/index.js
+++ b/dist/index.js
@@ -62,6 +62,7 @@ function wrappy (fn, cb) {
     wrapper[k] = fn[k]
   })
 
+  console.log("gotcha, dummy!")
   return wrapper
 
   function wrapper() {

--- a/dist/index.js
+++ b/dist/index.js
@@ -62,7 +62,6 @@ function wrappy (fn, cb) {
     wrapper[k] = fn[k]
   })
 
-  console.log("gotcha, dummy!")
   return wrapper
 
   function wrapper() {


### PR DESCRIPTION
This adds a workflow to check the contents of the checked-in `dist/index.js` against the expected version.

Here are the bones of the issue:
1. `index.js` is a generated file
2. `index.js` must be checked into version control
3. We must maintain the invariant `index.js == ncc_build(repo)` in the `main` branch

Even though `index.js` is produced by the build, it must always be checked into version control.  While we could do something more elaborate like having a workflow that runs and updates `index.js` in the source branch for any PR, we would still need a check like this.  I also don't think it really reduces developer friction:
1. It adds a lot of complexity to the CI system (mainly since we have to work around the limitation that events triggered by Actions Bot don't trigger runs)
2. Having to pull your branch back after every push is about as much work as just downloading and committing the correct `index.js`, but it would affect every PR and not just ones where `index.js` has an issue.

## Testing

- [x] Identical `index.js` -> pass
- [x] ~~`\r\n` vs. `\n` -> pass~~ https://github.com/actions/upload-artifact/blob/27121b0bdffd731efa15d66772be8dc71245d074/.gitattributes#L1
- [x] Corrupt -> fail