### PR TITLE
Fix YAML types in licensed.yml

### DIFF
--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -1,8 +1,12 @@
 name: Licensed
 
 on:
-  push: {branches: [main]}
-  pull_request: {branches: [main]}
+  push: 
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
 
 jobs:
   test:

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -1,8 +1,8 @@
 name: Licensed
 
 on:
-  push: {branches: main}
-  pull_request: {branches: main}
+  push: {branches: [main]}
+  pull_request: {branches: [main]}
 
 jobs:
   test:

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -1,12 +1,12 @@
 name: Licensed
 
 on:
-  push: 
+  push:
     branches:
-    - main
+      - main
   pull_request:
     branches:
-    - main
+      - main
 
 jobs:
   test:


### PR DESCRIPTION
I noticed this workflow running when it shouldn't:

![image](https://user-images.githubusercontent.com/33549821/123157910-242bb280-d439-11eb-9d5d-cfb772a0e137.png)

I think it's because the value for `branches` has to be an array.