### PR TITLE
Remove path filters

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -10,11 +10,9 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
   pull_request:
-    paths-ignore:
-      - '**.md'
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
@konradpabjan pointed out that we should make this a required check.  A check is still required even if it gets skipped, so I'm removing the path filter here.