### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -13,8 +13,7 @@ on:
   pull_request:
     branches:
       - main
-  workflow_dispatch:
-
+  workflow_dispatch: null
 jobs:
   check-dist:
     runs-on: ubuntu-latest
@@ -23,9 +22,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set Node.js 12.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 12.x
+          cache: npm
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,13 +4,12 @@ on:
     branches:
       - main
     paths-ignore:
-      - '**.md'
+      - "**.md"
   pull_request:
     paths-ignore:
-      - '**.md'
+      - "**.md"
 
 jobs:
-
   build:
     name: Build
 
@@ -22,149 +21,150 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Set Node.js 12.x
-      uses: actions/setup-node@v1
-      with:
-        node-version: 12.x
+      - name: Set Node.js 12.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+          cache: npm
 
-    - name: Install dependencies
-      run: npm ci
+      - name: Install dependencies
+        run: npm ci
 
-    - name: Compile
-      run: npm run build
+      - name: Compile
+        run: npm run build
 
-    - name: npm test
-      run: npm test
+      - name: npm test
+        run: npm test
 
-    - name: Lint
-      run: npm run lint
+      - name: Lint
+        run: npm run lint
 
-    - name: Format
-      run: npm run format-check
+      - name: Format
+        run: npm run format-check
 
-    # Test end-to-end by uploading two artifacts and then downloading them
-    - name: Create artifact files
-      run: |
-        mkdir -p path/to/dir-1
-        mkdir -p path/to/dir-2
-        mkdir -p path/to/dir-3    
-        echo "Lorem ipsum dolor sit amet" > path/to/dir-1/file1.txt
-        echo "Hello world from file #2" > path/to/dir-2/file2.txt
-        echo "This is a going to be a test for a large enough file that should get compressed with GZip. The @actions/artifact package uses GZip to upload files. This text should have a compression ratio greater than 100% so it should get uploaded using GZip" > path/to/dir-3/gzip.txt
+      # Test end-to-end by uploading two artifacts and then downloading them
+      - name: Create artifact files
+        run: |
+          mkdir -p path/to/dir-1
+          mkdir -p path/to/dir-2
+          mkdir -p path/to/dir-3    
+          echo "Lorem ipsum dolor sit amet" > path/to/dir-1/file1.txt
+          echo "Hello world from file #2" > path/to/dir-2/file2.txt
+          echo "This is a going to be a test for a large enough file that should get compressed with GZip. The @actions/artifact package uses GZip to upload files. This text should have a compression ratio greater than 100% so it should get uploaded using GZip" > path/to/dir-3/gzip.txt
 
-    # Upload a single file artifact
-    - name: 'Upload artifact #1'
-      uses: ./
-      with:
-        name: 'Artifact-A'
-        path: path/to/dir-1/file1.txt
+      # Upload a single file artifact
+      - name: "Upload artifact #1"
+        uses: ./
+        with:
+          name: "Artifact-A"
+          path: path/to/dir-1/file1.txt
 
-    # Upload using a wildcard pattern, name should default to 'artifact' if not provided
-    - name: 'Upload artifact #2'
-      uses: ./
-      with:
-        path: path/**/dir*/
+      # Upload using a wildcard pattern, name should default to 'artifact' if not provided
+      - name: "Upload artifact #2"
+        uses: ./
+        with:
+          path: path/**/dir*/
 
-    # Upload a directory that contains a file that will be uploaded with GZip
-    - name: 'Upload artifact #3'
-      uses: ./
-      with:
-        name: 'GZip-Artifact'
-        path: path/to/dir-3/
+      # Upload a directory that contains a file that will be uploaded with GZip
+      - name: "Upload artifact #3"
+        uses: ./
+        with:
+          name: "GZip-Artifact"
+          path: path/to/dir-3/
 
-    # Upload a directory that contains a file that will be uploaded with GZip
-    - name: 'Upload artifact #4'
-      uses: ./
-      with:
-        name: 'Multi-Path-Artifact'
-        path: |
-          path/to/dir-1/*
-          path/to/dir-[23]/*
-          !path/to/dir-3/*.txt
+      # Upload a directory that contains a file that will be uploaded with GZip
+      - name: "Upload artifact #4"
+        uses: ./
+        with:
+          name: "Multi-Path-Artifact"
+          path: |
+            path/to/dir-1/*
+            path/to/dir-[23]/*
+            !path/to/dir-3/*.txt
 
-    # Verify artifacts. Switch to download-artifact@v2 once it's out of preview
+      # Verify artifacts. Switch to download-artifact@v2 once it's out of preview
 
-    # Download Artifact #1 and verify the correctness of the content
-    - name: 'Download artifact #1'
-      uses: actions/download-artifact@v1
-      with:
-        name: 'Artifact-A'
-        path: some/new/path
+      # Download Artifact #1 and verify the correctness of the content
+      - name: "Download artifact #1"
+        uses: actions/download-artifact@v1
+        with:
+          name: "Artifact-A"
+          path: some/new/path
 
-    - name: 'Verify Artifact #1'
-      run: |
-        $file = "some/new/path/file1.txt"
-        if(!(Test-Path -path $file))
-        {
-            Write-Error "Expected file does not exist"
-        }
-        if(!((Get-Content $file) -ceq "Lorem ipsum dolor sit amet"))
-        {
-            Write-Error "File contents of downloaded artifact are incorrect"
-        }
-      shell: pwsh
+      - name: "Verify Artifact #1"
+        run: |
+          $file = "some/new/path/file1.txt"
+          if(!(Test-Path -path $file))
+          {
+              Write-Error "Expected file does not exist"
+          }
+          if(!((Get-Content $file) -ceq "Lorem ipsum dolor sit amet"))
+          {
+              Write-Error "File contents of downloaded artifact are incorrect"
+          }
+        shell: pwsh
 
-    # Download Artifact #2 and verify the correctness of the content
-    - name: 'Download artifact #2'
-      uses: actions/download-artifact@v1
-      with:
-        name: 'artifact'
-        path: some/other/path
+      # Download Artifact #2 and verify the correctness of the content
+      - name: "Download artifact #2"
+        uses: actions/download-artifact@v1
+        with:
+          name: "artifact"
+          path: some/other/path
 
-    - name: 'Verify Artifact #2'
-      run: |
-        $file1 = "some/other/path/to/dir-1/file1.txt"
-        $file2 = "some/other/path/to/dir-2/file2.txt"
-        if(!(Test-Path -path $file1) -or !(Test-Path -path $file2))
-        {
-            Write-Error "Expected files do not exist"
-        }
-        if(!((Get-Content $file1) -ceq "Lorem ipsum dolor sit amet") -or !((Get-Content $file2) -ceq "Hello world from file #2"))
-        {
-            Write-Error "File contents of downloaded artifacts are incorrect"
-        }
-      shell: pwsh
-    
-    # Download Artifact #3 and verify the correctness of the content
-    - name: 'Download artifact #3'
-      uses: actions/download-artifact@v1
-      with:
-        name: 'GZip-Artifact'
-        path: gzip/artifact/path
+      - name: "Verify Artifact #2"
+        run: |
+          $file1 = "some/other/path/to/dir-1/file1.txt"
+          $file2 = "some/other/path/to/dir-2/file2.txt"
+          if(!(Test-Path -path $file1) -or !(Test-Path -path $file2))
+          {
+              Write-Error "Expected files do not exist"
+          }
+          if(!((Get-Content $file1) -ceq "Lorem ipsum dolor sit amet") -or !((Get-Content $file2) -ceq "Hello world from file #2"))
+          {
+              Write-Error "File contents of downloaded artifacts are incorrect"
+          }
+        shell: pwsh
 
-    # Because a directory was used as input during the upload the parent directories, path/to/dir-3/, should not be included in the uploaded artifact
-    - name: 'Verify Artifact #3'
-      run: |
-        $gzipFile = "gzip/artifact/path/gzip.txt"
-        if(!(Test-Path -path $gzipFile))
-        {
-            Write-Error "Expected file do not exist"
-        }
-        if(!((Get-Content $gzipFile) -ceq "This is a going to be a test for a large enough file that should get compressed with GZip. The @actions/artifact package uses GZip to upload files. This text should have a compression ratio greater than 100% so it should get uploaded using GZip"))
-        {
-            Write-Error "File contents of downloaded artifact is incorrect"
-        }
-      shell: pwsh
+      # Download Artifact #3 and verify the correctness of the content
+      - name: "Download artifact #3"
+        uses: actions/download-artifact@v1
+        with:
+          name: "GZip-Artifact"
+          path: gzip/artifact/path
 
-    - name: 'Download artifact #4'
-      uses: actions/download-artifact@v1
-      with:
-        name: 'Multi-Path-Artifact'
-        path: multi/artifact
+      # Because a directory was used as input during the upload the parent directories, path/to/dir-3/, should not be included in the uploaded artifact
+      - name: "Verify Artifact #3"
+        run: |
+          $gzipFile = "gzip/artifact/path/gzip.txt"
+          if(!(Test-Path -path $gzipFile))
+          {
+              Write-Error "Expected file do not exist"
+          }
+          if(!((Get-Content $gzipFile) -ceq "This is a going to be a test for a large enough file that should get compressed with GZip. The @actions/artifact package uses GZip to upload files. This text should have a compression ratio greater than 100% so it should get uploaded using GZip"))
+          {
+              Write-Error "File contents of downloaded artifact is incorrect"
+          }
+        shell: pwsh
 
-    - name: 'Verify Artifact #4'
-      run: |
-        $file1 = "multi/artifact/dir-1/file1.txt"
-        $file2 = "multi/artifact/dir-2/file2.txt"
-        if(!(Test-Path -path $file1) -or !(Test-Path -path $file2))
-        {
-            Write-Error "Expected files do not exist"
-        }
-        if(!((Get-Content $file1) -ceq "Lorem ipsum dolor sit amet") -or !((Get-Content $file2) -ceq "Hello world from file #2"))
-        {
-            Write-Error "File contents of downloaded artifacts are incorrect"
-        }
-      shell: pwsh
+      - name: "Download artifact #4"
+        uses: actions/download-artifact@v1
+        with:
+          name: "Multi-Path-Artifact"
+          path: multi/artifact
+
+      - name: "Verify Artifact #4"
+        run: |
+          $file1 = "multi/artifact/dir-1/file1.txt"
+          $file2 = "multi/artifact/dir-2/file2.txt"
+          if(!(Test-Path -path $file1) -or !(Test-Path -path $file2))
+          {
+              Write-Error "Expected files do not exist"
+          }
+          if(!((Get-Content $file1) -ceq "Lorem ipsum dolor sit amet") -or !((Get-Content $file2) -ceq "Hello world from file #2"))
+          {
+              Write-Error "File contents of downloaded artifacts are incorrect"
+          }
+        shell: pwsh


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

Fix #235

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
