### PR TITLE
Fix `README.md` links and some formatting updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ See also [download-artifact](https://github.com/actions/download-artifact).
 
 # What's new
 
-- Easier upload 
+- Easier upload
   - Specify a wildcard pattern
   - Specify an individual file
   - Specify a directory (previously you were limited to only this option)
@@ -25,6 +25,7 @@ Refer [here](https://github.com/actions/upload-artifact/tree/releases/v1) for th
 See [action.yml](action.yml)
 
 ### Upload an Individual File
+
 ```yaml
 steps:
 - uses: actions/checkout@v2
@@ -49,6 +50,7 @@ steps:
 ```
 
 ### Upload using a Wildcard Pattern
+
 ```yaml
 - uses: actions/upload-artifact@v2
   with:
@@ -57,6 +59,7 @@ steps:
 ```
 
 ### Upload using Multiple Paths and Exclusions
+
 ```yaml
 - uses: actions/upload-artifact@v2
   with:
@@ -69,19 +72,20 @@ steps:
 
 For supported wildcards along with behavior and documentation, see [@actions/glob](https://github.com/actions/toolkit/tree/main/packages/glob) which is used internally to search for files.
 
-If a wildcard pattern is used, the path hierarchy will be preserved after the first wildcard pattern. 
+If a wildcard pattern is used, the path hierarchy will be preserved after the first wildcard pattern:
 
 ```
-    path/to/*/directory/foo?.txt =>
-        ∟ path/to/some/directory/foo1.txt
-        ∟ path/to/some/directory/foo2.txt
-        ∟ path/to/other/directory/foo1.txt
+path/to/*/directory/foo?.txt =>
+    ∟ path/to/some/directory/foo1.txt
+    ∟ path/to/some/directory/foo2.txt
+    ∟ path/to/other/directory/foo1.txt
 
-    would be flattened and uploaded as =>
-        ∟ some/directory/foo1.txt
-        ∟ some/directory/foo2.txt
-        ∟ other/directory/foo1.txt
+would be flattened and uploaded as =>
+    ∟ some/directory/foo1.txt
+    ∟ some/directory/foo2.txt
+    ∟ other/directory/foo1.txt
 ```
+
 If multiple paths are provided as input, the least common ancestor of all the search paths will be used as the root directory of the artifact. Exclude paths do not affect the directory structure.
 
 Relative and absolute file paths are both allowed. Relative paths are rooted against the current working directory. Paths that begin with a wildcard character should be quoted to avoid being interpreted as YAML aliases.
@@ -90,14 +94,14 @@ The [@actions/artifact](https://github.com/actions/toolkit/tree/main/packages/ar
 
 ### Customization if no files are found
 
-If a path (or paths), result in no files being found for the artifact, the action will succeed but print out a warning. In certain scenarios it may be desirable to fail the action or suppress the warning. The `if-no-files-found` option allows you to customize the behavior of the action if no files are found.
+If a path (or paths), result in no files being found for the artifact, the action will succeed but print out a warning. In certain scenarios it may be desirable to fail the action or suppress the warning. The `if-no-files-found` option allows you to customize the behavior of the action if no files are found:
 
 ```yaml
 - uses: actions/upload-artifact@v2
   with:
     name: my-artifact
     path: path/to/artifact/
-    if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn` 
+    if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
 ```
 
 ### Conditional Artifact Upload
@@ -115,6 +119,7 @@ To upload artifacts only when the previous step of a job failed, use [`if: failu
 ### Uploading without an artifact name
 
 You can upload an artifact without specifying a name
+
 ```yaml
 - uses: actions/upload-artifact@v2
   with:
@@ -125,7 +130,7 @@ If not provided, `artifact` will be used as the default name which will manifest
 
 ### Uploading to the same artifact
 
-With the following example, the available artifact (named `artifact` by default if no name is provided) would contain both `world.txt` (`hello`) and `extra-file.txt` (`howdy`).
+With the following example, the available artifact (named `artifact` by default if no name is provided) would contain both `world.txt` (`hello`) and `extra-file.txt` (`howdy`):
 
 ```yaml
 - run: echo hi > world.txt
@@ -144,9 +149,9 @@ With the following example, the available artifact (named `artifact` by default 
     path: world.txt
 ```
 
-> **_Warning:_**  Be careful when uploading to the same artifact via multiple jobs as artifacts may become corrupted 
+> **_Warning:_**  Be careful when uploading to the same artifact via multiple jobs as artifacts may become corrupted
 
-Each artifact behaves as a file share. Uploading to the same artifact multiple times in the same workflow can overwrite and append already uploaded files
+Each artifact behaves as a file share. Uploading to the same artifact multiple times in the same workflow can overwrite and append already uploaded files:
 
 ```yaml
     strategy:
@@ -162,7 +167,7 @@ Each artifact behaves as a file share. Uploading to the same artifact multiple t
               path: ${{ github.workspace }}
 ```
 
-In the above example, four jobs will upload four different files to the same artifact but there will only be one file available when `my-artifact` is downloaded. Each job overwrites what was previously uploaded. To ensure that jobs don't overwrite existing artifacts, use a different name per job.
+In the above example, four jobs will upload four different files to the same artifact but there will only be one file available when `my-artifact` is downloaded. Each job overwrites what was previously uploaded. To ensure that jobs don't overwrite existing artifacts, use a different name per job:
 
 ```yaml
           uses: 'actions/upload-artifact@v2'
@@ -173,30 +178,30 @@ In the above example, four jobs will upload four different files to the same art
 
 ### Environment Variables and Tilde Expansion
 
-You can use `~` in the path input as a substitute for `$HOME`. Basic tilde expansion is supported.
+You can use `~` in the path input as a substitute for `$HOME`. Basic tilde expansion is supported:
 
 ```yaml
-  - run: |	
+  - run: |
       mkdir -p ~/new/artifact
       echo hello > ~/new/artifact/world.txt
   - uses: actions/upload-artifact@v2
-    with:	
-      name: 'Artifacts-V2'	
+    with:
+      name: 'Artifacts-V2'
       path: '~/new/**/*'
 ```
 
-Environment variables along with context expressions can also be used for input. For documentation see [context and expression syntax](https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions).
+Environment variables along with context expressions can also be used for input. For documentation see [context and expression syntax](https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions):
 
 ```yaml
     env:
       name: my-artifact
     steps:
-    - run: |	
+    - run: |
         mkdir -p ${{ github.workspace }}/artifact
         echo hello > ${{ github.workspace }}/artifact/world.txt
     - uses: actions/upload-artifact@v2
-      with:	
-        name: ${{ env.name }}-name	
+      with:
+        name: ${{ env.name }}-name
         path: ${{ github.workspace }}/artifact/**/*
 ```
 
@@ -214,7 +219,6 @@ Artifacts are retained for 90 days by default. You can specify a shorter retenti
       name: my-artifact
       path: my_file.txt
       retention-days: 5
-
 ```
 
 The retention period must be between 1 and 90 inclusive. For more information see [artifact and log retention policies](https://docs.github.com/en/free-pro-team@latest/actions/reference/usage-limits-billing-and-administration#artifact-and-log-retention-policy).
@@ -233,7 +237,7 @@ The size of the artifact is denoted in bytes. The displayed artifact size denote
 
 ### Zipped Artifact Downloads
 
-During a workflow run, files are uploaded and downloaded individually using the `upload-artifact` and `download-artifact` actions. However, when a workflow run finishes and an artifact is downloaded from either the UI or through the [download api](https://developer.github.com/v3/actions/artifacts/#download-an-artifact), a zip is dynamically created with all the file contents that were uploaded. There is currently no way to download artifacts after a workflow run finishes in a format other than a zip or to download artifact contents individually. One of the consequences of this limitation is that if a zip is uploaded during a workflow run and then downloaded from the UI, there will be a double zip created. 
+During a workflow run, files are uploaded and downloaded individually using the `upload-artifact` and `download-artifact` actions. However, when a workflow run finishes and an artifact is downloaded from either the UI or through the [download api](https://developer.github.com/v3/actions/artifacts/#download-an-artifact), a zip is dynamically created with all the file contents that were uploaded. There is currently no way to download artifacts after a workflow run finishes in a format other than a zip or to download artifact contents individually. One of the consequences of this limitation is that if a zip is uploaded during a workflow run and then downloaded from the UI, there will be a double zip created.
 
 ### Permission Loss
 
@@ -245,18 +249,19 @@ During a workflow run, files are uploaded and downloaded individually using the 
 
 ### Maintaining file permissions and case sensitive files
 
-If file permissions and case sensitivity are required, you can `tar` all of your files together before artifact upload. Post download, the `tar` file will maintain file permissions and case sensitivity.
+If file permissions and case sensitivity are required, you can `tar` all of your files together before artifact upload. Post download, the `tar` file will maintain file permissions and case sensitivity:
 
 ```yaml
-  - name: 'Tar files'
+  - name: Tar files
     run: tar -cvf my_files.tar /path/to/my/directory
 
-  - name: 'Upload Artifact'
+  - name: Upload Artifact
     uses: actions/upload-artifact@v2
     with:
       name: my-artifact
-      path: my_files.tar    
+      path: my_files.tar
 ```
+
 ### Too many uploads resulting in 429 responses
 
 A very minute subset of users who upload a very very large amount of artifacts in a short period of time may see their uploads throttled or fail because of `Request was blocked due to exceeding usage of resource 'DBCPU' in namespace` or `Unable to copy file to server StatusCode=TooManyRequests`.
@@ -271,4 +276,4 @@ See extra documentation for the [@actions/artifact](https://github.com/actions/t
 
 # License
 
-The scripts and documentation in this project are released under the [MIT License](LICENSE)
+The scripts and documentation in this project are released under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ To reduce the chance of this happening, you can reduce the number of HTTP calls 
 
 ## Additional Documentation
 
-See [persisting workflow data using artifacts](https://help.github.com/en/actions/configuring-and-managing-workflows/persisting-workflow-data-using-artifacts) for additional examples and tips.
+See [Storing workflow data as artifacts](https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts) for additional examples and tips.
 
 See extra documentation for the [@actions/artifact](https://github.com/actions/toolkit/blob/master/packages/artifact/docs/additional-information.md) package that is used internally regarding certain behaviors and limitations.
 

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ To reduce the chance of this happening, you can reduce the number of HTTP calls 
 
 See [Storing workflow data as artifacts](https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts) for additional examples and tips.
 
-See extra documentation for the [@actions/artifact](https://github.com/actions/toolkit/blob/master/packages/artifact/docs/additional-information.md) package that is used internally regarding certain behaviors and limitations.
+See extra documentation for the [@actions/artifact](https://github.com/actions/toolkit/blob/main/packages/artifact/docs/additional-information.md) package that is used internally regarding certain behaviors and limitations.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -158,10 +158,10 @@ Each artifact behaves as a file share. Uploading to the same artifact multiple t
       matrix:
           node-version: [8.x, 10.x, 12.x, 13.x]
     steps:
-        - name: 'Create a file'
+        - name: Create a file
           run: echo ${{ matrix.node-version }} > my_file.txt
-        - name: 'Accidently upload to the same artifact via multiple jobs'
-          uses: 'actions/upload-artifact@v2'
+        - name: Accidently upload to the same artifact via multiple jobs
+          uses: actions/upload-artifact@v2
           with:
               name: my-artifact
               path: ${{ github.workspace }}
@@ -170,7 +170,7 @@ Each artifact behaves as a file share. Uploading to the same artifact multiple t
 In the above example, four jobs will upload four different files to the same artifact but there will only be one file available when `my-artifact` is downloaded. Each job overwrites what was previously uploaded. To ensure that jobs don't overwrite existing artifacts, use a different name per job:
 
 ```yaml
-          uses: 'actions/upload-artifact@v2'
+          uses: actions/upload-artifact@v2
           with:
               name: my-artifact ${{ matrix.node-version }}
               path: ${{ github.workspace }}
@@ -186,8 +186,8 @@ You can use `~` in the path input as a substitute for `$HOME`. Basic tilde expan
       echo hello > ~/new/artifact/world.txt
   - uses: actions/upload-artifact@v2
     with:
-      name: 'Artifacts-V2'
-      path: '~/new/**/*'
+      name: Artifacts-V2
+      path: ~/new/**/*
 ```
 
 Environment variables along with context expressions can also be used for input. For documentation see [context and expression syntax](https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions):
@@ -210,10 +210,10 @@ Environment variables along with context expressions can also be used for input.
 Artifacts are retained for 90 days by default. You can specify a shorter retention period using the `retention-days` input:
 
 ```yaml
-  - name: 'Create a file'
+  - name: Create a file
     run: echo "I won't live long" > my_file.txt
 
-  - name: 'Upload Artifact'
+  - name: Upload Artifact
     uses: actions/upload-artifact@v2
     with:
       name: my-artifact


### PR DESCRIPTION
- Noted that the link to `persisting workflow data using artifacts` had updated URL and title.
- While in the area, cleaned up some formatting (whitespace and `:` use) and fixed a few other links.
- Removed some single quotes from YAML examples as well.
- Trailing whitespace trimmed.