### PR TITLE
Document how to correctly use environment variables for path input

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ For environment variables created in other steps, make sure to use the `env` exp
     - uses: actions/upload-artifact@v2
       with:
         name: artifact
-        path: ${{ env.artifactPath }}
+        path: ${{ env.artifactPath }} # this will resolve to testing/file.txt at runtime
 ```
 
 ### Retention Period

--- a/README.md
+++ b/README.md
@@ -205,6 +205,20 @@ Environment variables along with context expressions can also be used for input.
         path: ${{ github.workspace }}/artifact/**/*
 ```
 
+For environment variables created in other steps, make sure to use the `env` expression syntax
+
+```
+    steps:
+    - run: | 
+        mkdir testing
+        echo "This is a file to upload" > testing/file.txt
+        echo "artifactPath=testing/file.txt" >> $GITHUB_ENV
+    - uses: actions/upload-artifact@v2
+      with:
+        name: artifact
+        path: ${{ env.artifactPath }}
+```
+
 ### Retention Period
 
 Artifacts are retained for 90 days by default. You can specify a shorter retention period using the `retention-days` input:


### PR DESCRIPTION
Resolves: https://github.com/actions/upload-artifact/issues/242

Sample run I used for testing: https://github.com/konradpabjan/artifact-test/runs/4386338187?check_suite_focus=true#step:3:20

Identical behavior if just `testing/file.txt` is provided: https://github.com/konradpabjan/artifact-test/actions/runs/1527468274


