### PR TITLE
Create release-new-action-version.yml

### DIFF
--- a/.github/workflows/release-new-action-version.yml
+++ b/.github/workflows/release-new-action-version.yml
@@ -1,0 +1,28 @@
+name: Release new action version
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      TAG_NAME:
+        description: 'Tag name that the major tag will point to'
+        required: true
+
+env:
+  TAG_NAME: ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }}
+permissions:
+  contents: write
+
+jobs:
+  update_tag:
+    name: Update the major tag to include the ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }} changes
+    environment:
+      name: releaseNewActionVersion
+    runs-on: ubuntu-latest
+    steps:
+    - name: Update the ${{ env.TAG_NAME }} tag
+      id: update-major-tag
+      uses: actions/publish-action@v0.1.0
+      with:
+        source-tag: ${{ env.TAG_NAME }}
+        slack-webhook: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
This helps automate releasing a new version of the action without manually having to update minor tags.

This is similar to what other first part actions are doing like `setup-python` and `setup-java`.

See:
https://github.com/actions/setup-java/blob/main/.github/workflows/release-new-action-version.yml
https://github.com/actions/setup-python/blob/main/.github/workflows/release-new-action-version.yml

We use the following action:
https://github.com/actions/publish-action

A new environment was created with the slack_webhook URL as a secret: https://github.com/actions/upload-artifact/settings/environments/346640120/edit