### PR TITLE
Bump @actions/artifact to version 0.6.1

### DIFF
--- a/.licenses/npm/@actions/artifact.dep.yml
+++ b/.licenses/npm/@actions/artifact.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: "@actions/artifact"
-version: 0.6.0
+version: 0.6.1
 type: npm
 summary: 
 homepage: 

--- a/dist/index.js
+++ b/dist/index.js
@@ -7078,9 +7078,7 @@ class UploadHttpClient {
         return __awaiter(this, void 0, void 0, function* () {
             const fileStat = yield stat(parameters.file);
             const totalFileSize = fileStat.size;
-            // on Windows with mkfifo from MSYS2 stats.isFIFO returns false, so we check if running on Windows node and
-            // if the file has size of 0 to compensate
-            const isFIFO = fileStat.isFIFO() || (process.platform === 'win32' && totalFileSize === 0);
+            const isFIFO = fileStat.isFIFO();
             let offset = 0;
             let isUploadSuccessful = true;
             let failedChunkSizes = 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@actions/artifact": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-0.6.0.tgz",
-      "integrity": "sha512-o/rT5tJQEXn1mTJhbaNEhC7VO6gNHroDAcalxYSU4VJcrMhkMSBMc5uQ4Uvmdl+lc+Fa2EEzwzPLoYbrXKclGw==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-0.6.1.tgz",
+      "integrity": "sha512-rZ1k9kQvJX21Vwgx1L6kSQ6yeXo9cCMyqURSnjG+MRoJn+Mr3LblxmVdzScHXRzv0N9yzy49oG7Bqxp9Knyv/g==",
       "requires": {
         "@actions/core": "^1.2.6",
         "@actions/http-client": "^1.0.11",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/actions/upload-artifact#readme",
   "dependencies": {
-    "@actions/artifact": "^0.6.0",
+    "@actions/artifact": "^0.6.1",
     "@actions/core": "^1.2.6",
     "@actions/glob": "^0.1.0",
     "@actions/io": "^1.0.2"


### PR DESCRIPTION
Bump `@actions/artifact` to version 0.6.1 https://www.npmjs.com/package/@actions/artifact/v/0.6.1 which has a fix for https://github.com/actions/upload-artifact/issues/281