### PR TITLE
README: Bump actions/checkout to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ See [action.yml](action.yml)
 
 ```yaml
 steps:
-- uses: actions/checkout@v2
+- uses: actions/checkout@v3
 
 - run: mkdir -p path/to/artifact
 


### PR DESCRIPTION
`Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/checkout`

It's great to have non-deprecated examples.