### PR TITLE
README: update actions/checkout to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ See [action.yml](action.yml)
 
 ```yaml
 steps:
-- uses: actions/checkout@v2
+- uses: actions/checkout@v3
 
 - run: mkdir -p path/to/artifact
 


### PR DESCRIPTION
actions/checkout@v2 uses node v12 which is deprecated, so better to use the current version for anyone who copies and pastes this example