### PR TITLE
Fix typ in bug-report.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -51,7 +51,7 @@ body:
       options:
         - self-hosted
         - linux
-        - window
+        - windows
         - macos
     validations:
       required: true


### PR DESCRIPTION
The operating system name of Microsoft Windows (in lower case) is `windows` with an "s". This PR adds that.