### PR TITLE
Update action to node20

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -22,10 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup Node 16
+      - name: Setup Node 20
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 20.x
           cache: 'npm'
   
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,10 +25,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Setup Node 16
+    - name: Setup Node 20
       uses: actions/setup-node@v3
       with:
-        node-version: 16.x
+        node-version: 20.x
         cache: 'npm'
 
     - name: Install dependencies

--- a/action.yml
+++ b/action.yml
@@ -24,5 +24,5 @@ inputs:
       Minimum 1 day.
       Maximum 90 days unless changed from the repository settings page.
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Node 16 has reached end-of-life on 11 Sep 202.
This PR updates the default runtime to node20, rather then node16.

This is supported on all Actions Runners [v2.308.0](https://github.com/actions/runner/releases/tag/v2.308.0) or later.