### PR TITLE
Consume latest @actions/artifact

### DIFF
--- a/src/upload-artifact.ts
+++ b/src/upload-artifact.ts
@@ -1,6 +1,6 @@
 import * as core from '../node_modules/@actions/core/'
 import {
-  UploadOptions,
+  UploadArtifactOptions,
   create
 } from '../node_modules/@actions/artifact/lib/artifact'
 import {findFilesToUpload} from './search'
@@ -41,7 +41,7 @@ async function run(): Promise<void> {
       core.debug(`Root artifact directory is ${searchResult.rootDirectory}`)
 
       const artifactClient = create()
-      const options: UploadOptions = {}
+      const options: UploadArtifactOptions = {}
       if (inputs.retentionDays) {
         options.retentionDays = inputs.retentionDays
       }


### PR DESCRIPTION
Includes changes from:
- https://github.com/actions/toolkit/pull/1591
- https://github.com/actions/toolkit/pull/1592

For uploads, this is just some minor interface renames. Otherwise behavior is the same.