### PR TITLE
Document relative paths rooted against workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ would be flattened and uploaded as =>
 
 If multiple paths are provided as input, the least common ancestor of all the search paths will be used as the root directory of the artifact. Exclude paths do not affect the directory structure.
 
-Relative and absolute file paths are both allowed. Relative paths are rooted against the current working directory. Paths that begin with a wildcard character should be quoted to avoid being interpreted as YAML aliases.
+Relative and absolute file paths are both allowed. Relative paths are rooted against the workspace. Paths that begin with a wildcard character should be quoted to avoid being interpreted as YAML aliases.
 
 ### Altering compressions level (speed v. size)
 


### PR DESCRIPTION
same as #318

The documentation currently states that "Relative paths are rooted against the current working directory". This can lead a caller to think that the [default working-directory](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#defaultsrun) applies to this action whereas it does not (the default working-directory only applies to the run steps).

I reworded the sentence to state "Relative paths are rooted against the workspace." which I think is clearer.

Fix https://github.com/actions/upload-artifact/issues/294 fix https://github.com/actions/upload-artifact/issues/246 fix https://github.com/actions/upload-artifact/issues/87