### PR TITLE
Using node18 to support centOS 7 runners

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,5 +42,5 @@ outputs:
 
       This ID can be used as input to other APIs to download, delete or get more information about an artifact: https://docs.github.com/en/rest/actions/artifacts
 runs:
-  using: 'node16'
+  using: 'node18'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -42,5 +42,5 @@ outputs:
 
       This ID can be used as input to other APIs to download, delete or get more information about an artifact: https://docs.github.com/en/rest/actions/artifacts
 runs:
-  using: 'node20'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
To support CentOS 7 that is not compatible with node20, we need to keep a fork of v4 release that would work with centOS 7 self-hosted runners

Ref issue: https://github.com/actions/runner/issues/2906