### PR TITLE
Update limitation of `10` artifacts upload to `500`

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ jobs:
 
 ### Number of Artifacts
 
-Within an individual job, there is a limit of 10 artifacts that can be created for that job.
+Within an individual job, there is a limit of 500 artifacts that can be created for that job.
 
 You may also be limited by Artifacts if you have exceeded your shared storage quota. Storage is calculated every 6-12 hours. See [the documentation](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#calculating-minute-and-storage-spending) for more info.
 


### PR DESCRIPTION
According to https://github.com/actions/upload-artifact/issues/470#issuecomment-1885881535, the limitation has been raised from `10` to `500`. This PR simply updates the docs to reflect the change.