### PR TITLE
Fix typo with v3 artifact downloads in migration guide

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -32,6 +32,7 @@ jobs:
       - name: Download All Artifacts
         uses: actions/download-artifact@v3
         with:
+          name: my-artifact
           path: my-artifact
       - run: ls -R my-artifact
 ```
@@ -72,6 +73,7 @@ jobs:
 -     uses: actions/download-artifact@v3
 +     uses: actions/download-artifact@v4
       with:
+-       name: my-artifact
         path: my-artifact
 +       pattern: my-artifact-*
 +       merge-multiple: true


### PR DESCRIPTION
In the migration guide, the download for the v3 was as follows:

```yaml
      - name: Download All Artifacts
        uses: actions/download-artifact@v3
        with:
          path: my-artifact
      - run: ls -R my-artifact
```

And it was stated that it would create the following directory:

```
my-artifact/
  file-macos-latest.txt
  file-ubuntu-latest.txt
  file-windows-latest.txt
```

This was incorrect, since no `name` was specified, it actually made an inner directory due to the behavior outlined [here in the v3 docs](https://github.com/actions/download-artifact/tree/v3?tab=readme-ov-file#download-all-artifacts).

> If the name input parameter is not provided, all artifacts will be downloaded. To differentiate between downloaded artifacts, a directory denoted by the artifacts name will be created for each individual artifact.

Instead we must provide both the name and the path to have it match the scenario we outlined.