### PR TITLE
Update release-new-action-version.yml

### DIFF
--- a/.github/workflows/release-new-action-version.yml
+++ b/.github/workflows/release-new-action-version.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - name: Update the ${{ env.TAG_NAME }} tag
       id: update-major-tag
-      uses: actions/publish-action@v0.2.1
+      uses: actions/publish-action@v0.3.0
       with:
         source-tag: ${{ env.TAG_NAME }}
         slack-webhook: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
V0.2.1 runs on node16 which generates a warning annotation when it is used. V0.3.0 is the latest and it uses node20: https://github.com/actions/publish-action/tags