### PR TITLE
V3 backport: Exclude hidden files by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,29 @@ Artifacts are retained for 90 days by default. You can specify a shorter retenti
 
 The retention period must be between 1 and 90 inclusive. For more information see [artifact and log retention policies](https://docs.github.com/en/free-pro-team@latest/actions/reference/usage-limits-billing-and-administration#artifact-and-log-retention-policy).
 
+
+### Hidden Files 
+
+By default, hidden files are ignored by this action to avoid unintentionally uploading sensitive information.
+
+In versions of this action before v3.2.0, these hidden files were included by default.
+
+If you need to upload hidden files, you can use the `include-hidden-files` input.
+
+```yaml
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create a Hidden File
+        run: echo "hello from a hidden file" > .hidden-file.txt
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          path: .hidden-file.txt
+          include-hidden-files: true
+```
+
 ## Where does the upload go?
 
 At the bottom of the workflow summary page, there is a dedicated section for artifacts. Here's a screenshot of something you might see:

--- a/__tests__/search.test.ts
+++ b/__tests__/search.test.ts
@@ -61,6 +61,20 @@ const lonelyFilePath = path.join(
   'lonely-file.txt'
 )
 
+const hiddenFile = path.join(root, '.hidden-file.txt')
+const fileInHiddenFolderPath = path.join(
+  root,
+  '.hidden-folder',
+  'folder-in-hidden-folder',
+  'file.txt'
+)
+const fileInHiddenFolderInFolderA = path.join(
+  root,
+  'folder-a',
+  '.hidden-folder-in-folder-a',
+  'file.txt'
+)
+
 describe('Search', () => {
   beforeAll(async () => {
     // mock all output so that there is less noise when running tests
@@ -92,6 +106,13 @@ describe('Search', () => {
     await fs.mkdir(path.join(root, 'folder-h', 'folder-j', 'folder-k'), {
       recursive: true
     })
+    await fs.mkdir(
+      path.join(root, '.hidden-folder', 'folder-in-hidden-folder'),
+      {recursive: true}
+    )
+    await fs.mkdir(path.join(root, 'folder-a', '.hidden-folder-in-folder-a'), {
+      recursive: true
+    })
 
     await fs.writeFile(searchItem1Path, 'search item1 file')
     await fs.writeFile(searchItem2Path, 'search item2 file')
@@ -110,10 +131,19 @@ describe('Search', () => {
     await fs.writeFile(amazingFileInFolderHPath, 'amazing file')
 
     await fs.writeFile(lonelyFilePath, 'all by itself')
+
+    await fs.writeFile(hiddenFile, 'hidden file')
+    await fs.writeFile(fileInHiddenFolderPath, 'file in hidden directory')
+    await fs.writeFile(fileInHiddenFolderInFolderA, 'file in hidden directory')
     /*
       Directory structure of files that get created:
       root/
+          .hidden-folder/
+            folder-in-hidden-folder/
+              file.txt
           folder-a/
+              .hidden-folder-in-folder-a/
+                file.txt
               folder-b/
                   folder-c/
                       search-item1.txt
@@ -136,6 +166,7 @@ describe('Search', () => {
               folder-j/
                   folder-k/
                       lonely-file.txt
+          .hidden-file.txt
           search-item5.txt
     */
   })
@@ -351,5 +382,25 @@ describe('Search', () => {
       true
     )
     expect(searchResult.filesToUpload.includes(lonelyFilePath)).toEqual(true)
+  })
+
+  it('Hidden files ignored by default', async () => {
+    const searchPath = path.join(root, '**/*')
+    const searchResult = await findFilesToUpload(searchPath)
+
+    expect(searchResult.filesToUpload).not.toContain(hiddenFile)
+    expect(searchResult.filesToUpload).not.toContain(fileInHiddenFolderPath)
+    expect(searchResult.filesToUpload).not.toContain(
+      fileInHiddenFolderInFolderA
+    )
+  })
+
+  it('Hidden files included', async () => {
+    const searchPath = path.join(root, '**/*')
+    const searchResult = await findFilesToUpload(searchPath, true)
+
+    expect(searchResult.filesToUpload).toContain(hiddenFile)
+    expect(searchResult.filesToUpload).toContain(fileInHiddenFolderPath)
+    expect(searchResult.filesToUpload).toContain(fileInHiddenFolderInFolderA)
   })
 })

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,11 @@ inputs:
 
       Minimum 1 day.
       Maximum 90 days unless changed from the repository settings page.
+  include-hidden-files:
+    description: >
+      If true, hidden files will be included in the uploaded artifact.
+      If false, hidden files will be excluded from the uploaded artifact.
+    default: 'false'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@actions/artifact": "^1.1.2",
         "@actions/core": "^1.10.0",
-        "@actions/glob": "^0.3.0",
+        "@actions/glob": "^0.5.0",
         "@actions/io": "^1.1.2"
       },
       "devDependencies": {
@@ -52,11 +52,11 @@
       }
     },
     "node_modules/@actions/glob": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@actions/glob/-/glob-0.3.0.tgz",
-      "integrity": "sha512-tJP1ZhF87fd6LBnaXWlahkyvdgvsLl7WnreW1EZaC8JWjpMXmzqWzQVe/IEYslrkT9ymibVrKyJN4UMD7uQM2w==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@actions/glob/-/glob-0.5.0.tgz",
+      "integrity": "sha512-tST2rjPvJLRZLuT9NMUtyBjvj9Yo0MiJS3ow004slMvm8GFM+Zv9HvMJ7HWzfUyJnGrJvDsYkWBaaG3YKXRtCw==",
       "dependencies": {
-        "@actions/core": "^1.2.6",
+        "@actions/core": "^1.9.1",
         "minimatch": "^3.0.4"
       }
     },
@@ -6168,11 +6168,11 @@
       }
     },
     "@actions/glob": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@actions/glob/-/glob-0.3.0.tgz",
-      "integrity": "sha512-tJP1ZhF87fd6LBnaXWlahkyvdgvsLl7WnreW1EZaC8JWjpMXmzqWzQVe/IEYslrkT9ymibVrKyJN4UMD7uQM2w==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@actions/glob/-/glob-0.5.0.tgz",
+      "integrity": "sha512-tST2rjPvJLRZLuT9NMUtyBjvj9Yo0MiJS3ow004slMvm8GFM+Zv9HvMJ7HWzfUyJnGrJvDsYkWBaaG3YKXRtCw==",
       "requires": {
-        "@actions/core": "^1.2.6",
+        "@actions/core": "^1.9.1",
         "minimatch": "^3.0.4"
       }
     },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@actions/artifact": "^1.1.2",
     "@actions/core": "^1.10.0",
-    "@actions/glob": "^0.3.0",
+    "@actions/glob": "^0.5.0",
     "@actions/io": "^1.1.2"
   },
   "devDependencies": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,8 @@ export enum Inputs {
   Name = 'name',
   Path = 'path',
   IfNoFilesFound = 'if-no-files-found',
-  RetentionDays = 'retention-days'
+  RetentionDays = 'retention-days',
+  IncludeHiddenFiles = 'include-hidden-files'
 }
 
 export enum NoFileOptions {

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -11,6 +11,7 @@ export function getInputs(): UploadInputs {
 
   const ifNoFilesFound = core.getInput(Inputs.IfNoFilesFound)
   const noFileBehavior: NoFileOptions = NoFileOptions[ifNoFilesFound]
+  const includeHiddenFiles = core.getBooleanInput(Inputs.IncludeHiddenFiles)
 
   if (!noFileBehavior) {
     core.setFailed(
@@ -25,7 +26,8 @@ export function getInputs(): UploadInputs {
   const inputs = {
     artifactName: name,
     searchPath: path,
-    ifNoFilesFound: noFileBehavior
+    ifNoFilesFound: noFileBehavior,
+    includeHiddenFiles
   } as UploadInputs
 
   const retentionDaysStr = core.getInput(Inputs.RetentionDays)

--- a/src/search.ts
+++ b/src/search.ts
@@ -11,11 +11,12 @@ export interface SearchResult {
   rootDirectory: string
 }
 
-function getDefaultGlobOptions(): glob.GlobOptions {
+function getDefaultGlobOptions(includeHiddenFiles: boolean): glob.GlobOptions {
   return {
     followSymbolicLinks: true,
     implicitDescendants: true,
-    omitBrokenSymbolicLinks: true
+    omitBrokenSymbolicLinks: true,
+    excludeHiddenFiles: !includeHiddenFiles
   }
 }
 
@@ -80,12 +81,12 @@ function getMultiPathLCA(searchPaths: string[]): string {
 
 export async function findFilesToUpload(
   searchPath: string,
-  globOptions?: glob.GlobOptions
+  includeHiddenFiles?: boolean
 ): Promise<SearchResult> {
   const searchResults: string[] = []
   const globber = await glob.create(
     searchPath,
-    globOptions || getDefaultGlobOptions()
+    getDefaultGlobOptions(includeHiddenFiles || false)
   )
   const rawSearchResults: string[] = await globber.glob()
 

--- a/src/upload-inputs.ts
+++ b/src/upload-inputs.ts
@@ -20,4 +20,9 @@ export interface UploadInputs {
    * Duration after which artifact will expire in days
    */
   retentionDays: number
+
+  /**
+   * Whether or not to include hidden files in the artifact
+   */
+  includeHiddenFiles: boolean
 }


### PR DESCRIPTION
- #602 
- #598 

This is a backport from the latest behavioral change for `artifact-upload` v4.4.0. 

Currently, all files within the search path are uploaded into the artifact. This includes hidden files, which could contain sensitive values that should not be accessible outside of the workflow run. To enhance the default security of this action, this PR excludes hidden files from the path by default. Users who require hidden files have validated that there are no sensitive values in their artifacts can opt-in to uploading hidden files with the include-hidden-files input.

This is part of the following breaking change:

> Exclude hidden files by default in Upload Artifact GitHub Actions
From September 2nd, 2024, we will no longer include hidden files and folders as part of the default upload of the v3 and v4 upload-artifact actions. This reduces the risk that credentials are accidentally uploaded into artifacts. Customers who need to continue to upload these files can use a new option, ‘include-hidden-files’, to continue to do so.
https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/