### PR TITLE
Ensure hidden files input is used

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -11091,7 +11091,7 @@ function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const inputs = (0, input_helper_1.getInputs)();
-            const searchResult = yield (0, search_1.findFilesToUpload)(inputs.searchPath);
+            const searchResult = yield (0, search_1.findFilesToUpload)(inputs.searchPath, inputs.includeHiddenFiles);
             if (searchResult.filesToUpload.length === 0) {
                 // No files were found, different use cases warrant different types of behavior if nothing is found
                 switch (inputs.ifNoFilesFound) {

--- a/src/upload-artifact.ts
+++ b/src/upload-artifact.ts
@@ -7,7 +7,10 @@ import {NoFileOptions} from './constants'
 async function run(): Promise<void> {
   try {
     const inputs = getInputs()
-    const searchResult = await findFilesToUpload(inputs.searchPath)
+    const searchResult = await findFilesToUpload(
+      inputs.searchPath,
+      inputs.includeHiddenFiles
+    )
     if (searchResult.filesToUpload.length === 0) {
       // No files were found, different use cases warrant different types of behavior if nothing is found
       switch (inputs.ifNoFilesFound) {


### PR DESCRIPTION
- #602
- #608

In #604/#606, the `include-hidden-files` input is never used so users cannot opt-into including hidden files in their artifact.


With this change, we're now matching `v4.4.0` which properly respects this input:
https://github.com/actions/upload-artifact/blob/v4.4.0/src/upload/upload-artifact.ts#L27-L30