### PR TITLE
Warn excluded hidden files

### DIFF
--- a/__tests__/search.test.ts
+++ b/__tests__/search.test.ts
@@ -386,6 +386,7 @@ describe('Search', () => {
   })
 
   it('Hidden files ignored by default', async () => {
+    const warningSpy = jest.spyOn(core, 'warning')
     const searchPath = path.join(root, '**/*')
     const searchResult = await findFilesToUpload(searchPath)
 
@@ -394,14 +395,19 @@ describe('Search', () => {
     expect(searchResult.filesToUpload).not.toContain(
       fileInHiddenFolderInFolderA
     )
+    expect(warningSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/Set include-hidden-files to true to include these files.$/)
+    )
   })
 
   it('Hidden files included', async () => {
+    const warningSpy = jest.spyOn(core, 'warning')
     const searchPath = path.join(root, '**/*')
     const searchResult = await findFilesToUpload(searchPath, true)
 
     expect(searchResult.filesToUpload).toContain(hiddenFile)
     expect(searchResult.filesToUpload).toContain(fileInHiddenFolderPath)
     expect(searchResult.filesToUpload).toContain(fileInHiddenFolderInFolderA)
+    expect(warningSpy).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Resolves #447.

While I agree to the breaking change introduced by #602, it is not intuitive. Hence I would like the action to warn when it excludes hidden files.