### PR TITLE
Simplified logic for handling "no files" upload notification

### DIFF
--- a/src/upload/constants.ts
+++ b/src/upload/constants.ts
@@ -1,3 +1,5 @@
+import {info, setFailed, warning} from '@actions/core'
+
 /* eslint-disable no-unused-vars */
 export enum Inputs {
   Name = 'name',
@@ -25,3 +27,9 @@ export enum NoFileOptions {
    */
   ignore = 'ignore'
 }
+
+export const NoFileFunctionMap = {
+  [NoFileOptions.error]: setFailed,
+  [NoFileOptions.ignore]: info,
+  [NoFileOptions.warn]: warning
+} as const

--- a/src/upload/upload-artifact.ts
+++ b/src/upload/upload-artifact.ts
@@ -5,7 +5,7 @@ import artifact, {
 } from '@actions/artifact'
 import {findFilesToUpload} from '../shared/search'
 import {getInputs} from './input-helper'
-import {NoFileOptions} from './constants'
+import {NoFileFunctionMap, NoFileOptions} from './constants'
 import {uploadArtifact} from '../shared/upload-artifact'
 
 async function deleteArtifactIfExists(artifactName: string): Promise<void> {
@@ -30,51 +30,35 @@ export async function run(): Promise<void> {
   )
   if (searchResult.filesToUpload.length === 0) {
     // No files were found, different use cases warrant different types of behavior if nothing is found
-    switch (inputs.ifNoFilesFound) {
-      case NoFileOptions.warn: {
-        core.warning(
-          `No files were found with the provided path: ${inputs.searchPath}. No artifacts will be uploaded.`
-        )
-        break
-      }
-      case NoFileOptions.error: {
-        core.setFailed(
-          `No files were found with the provided path: ${inputs.searchPath}. No artifacts will be uploaded.`
-        )
-        break
-      }
-      case NoFileOptions.ignore: {
-        core.info(
-          `No files were found with the provided path: ${inputs.searchPath}. No artifacts will be uploaded.`
-        )
-        break
-      }
-    }
-  } else {
-    const s = searchResult.filesToUpload.length === 1 ? '' : 's'
-    core.info(
-      `With the provided path, there will be ${searchResult.filesToUpload.length} file${s} uploaded`
+    NoFileFunctionMap[inputs.ifNoFilesFound]?.(
+      `No files were found with the provided path: ${inputs.searchPath}. No artifacts will be uploaded.`
     )
-    core.debug(`Root artifact directory is ${searchResult.rootDirectory}`)
-
-    if (inputs.overwrite) {
-      await deleteArtifactIfExists(inputs.artifactName)
-    }
-
-    const options: UploadArtifactOptions = {}
-    if (inputs.retentionDays) {
-      options.retentionDays = inputs.retentionDays
-    }
-
-    if (typeof inputs.compressionLevel !== 'undefined') {
-      options.compressionLevel = inputs.compressionLevel
-    }
-
-    await uploadArtifact(
-      inputs.artifactName,
-      searchResult.filesToUpload,
-      searchResult.rootDirectory,
-      options
-    )
+    return
   }
+
+  const s = searchResult.filesToUpload.length === 1 ? '' : 's'
+  core.info(
+    `With the provided path, there will be ${searchResult.filesToUpload.length} file${s} uploaded`
+  )
+  core.debug(`Root artifact directory is ${searchResult.rootDirectory}`)
+
+  if (inputs.overwrite) {
+    await deleteArtifactIfExists(inputs.artifactName)
+  }
+
+  const options: UploadArtifactOptions = {}
+  if (inputs.retentionDays) {
+    options.retentionDays = inputs.retentionDays
+  }
+
+  if (typeof inputs.compressionLevel !== 'undefined') {
+    options.compressionLevel = inputs.compressionLevel
+  }
+
+  await uploadArtifact(
+    inputs.artifactName,
+    searchResult.filesToUpload,
+    searchResult.rootDirectory,
+    options
+  )
 }


### PR DESCRIPTION
## Changes

* Created a constant that maps the `NoFileOptions` to their corresponding `core` methods
* Switched to early exit/`return` pattern to further simplify and de-indent the code
    Everything after the `return` statement is just [white-space changes](https://github.com/actions/upload-artifact/pull/729/files?w=1).

> [!NOTE]
>
> There is no change in functionality here.