### PR TITLE
Implement overwrite behavior for skip archive artifact

### DIFF
--- a/__tests__/upload.test.ts
+++ b/__tests__/upload.test.ts
@@ -327,4 +327,26 @@ describe('upload', () => {
     )
     expect(artifact.default.uploadArtifact).not.toHaveBeenCalled()
   })
+
+  test('overwrite artifact by filename when archive is false', async () => {
+    mockInputs({
+      [Inputs.Archive]: false,
+      [Inputs.Overwrite]: true
+    })
+
+    mockFindFilesToUpload.mockResolvedValue({
+      filesToUpload: [fixtures.filesToUpload[0]],
+      rootDirectory: fixtures.rootDirectory
+    })
+
+    jest.spyOn(artifact.default, 'deleteArtifact').mockResolvedValue({
+      id: 1337
+    })
+
+    await run()
+
+    expect(artifact.default.deleteArtifact).toHaveBeenCalledWith(
+      fixtures.filesToUpload[0].split('/').pop() || ''
+    )
+  })
 })

--- a/src/upload/upload-artifact.ts
+++ b/src/upload/upload-artifact.ts
@@ -66,7 +66,16 @@ export async function run(): Promise<void> {
     }
 
     if (inputs.overwrite) {
-      await deleteArtifactIfExists(inputs.artifactName)
+      if (!inputs.archive) {
+        if (searchResult.filesToUpload.length > 0) {
+          const fileName = searchResult.filesToUpload[0].split('/').pop()
+          if (fileName) {
+            deleteArtifactIfExists(fileName)
+          }
+        }
+      } else {
+        await deleteArtifactIfExists(inputs.artifactName)
+      }
     }
 
     const options: UploadArtifactOptions = {}


### PR DESCRIPTION
## Description
This PR fixes the behavior of the upload action when `archive` is set to `false` and `overwrite` is set to `true`.

Previously, the overwrite logic only deletes existing artifacts by the artifact name.

According to `action.yml`:

https://github.com/actions/upload-artifact/blob/bbbca2ddaa5d8feaa63e36b76fdaad77386f024f/action.yml#L52

Therefore, when `overwrite: true` is enabled, the action must delete the existing artifact using the **filename** as the artifact name, rather than using the `name` input parameter (which is ignored).


## Related Issues
Fixes #769 

