### PR TITLE
Display artifact upload size in human-readable format

### DIFF
--- a/dist/merge/index.js
+++ b/dist/merge/index.js
@@ -131843,7 +131843,15 @@ function getInputs() {
 
 async function upload_artifact_uploadArtifact(artifactName, filesToUpload, rootDirectory, options) {
     const uploadResponse = await lib_artifact.uploadArtifact(artifactName, filesToUpload, rootDirectory, options);
-    info(`Artifact ${artifactName} has been successfully uploaded! Final size is ${uploadResponse.size} bytes. Artifact ID is ${uploadResponse.id}`);
+    const size = uploadResponse.size;
+    const displaySize = size === undefined
+        ? 'unknown'
+        : size >= 1024 * 1024
+            ? `${(size / (1024 * 1024)).toFixed(2)} MB`
+            : size >= 1024
+                ? `${(size / 1024).toFixed(2)} KB`
+                : `${size} bytes`;
+    info(`Artifact ${artifactName} has been successfully uploaded! Final size is ${displaySize}. Artifact ID is ${uploadResponse.id}`);
     setOutput('artifact-id', uploadResponse.id);
     setOutput('artifact-digest', uploadResponse.digest);
     const repository = github_context.repo;

--- a/dist/upload/index.js
+++ b/dist/upload/index.js
@@ -130526,7 +130526,15 @@ function getInputs() {
 
 async function upload_artifact_uploadArtifact(artifactName, filesToUpload, rootDirectory, options) {
     const uploadResponse = await artifact.uploadArtifact(artifactName, filesToUpload, rootDirectory, options);
-    info(`Artifact ${artifactName} has been successfully uploaded! Final size is ${uploadResponse.size} bytes. Artifact ID is ${uploadResponse.id}`);
+    const size = uploadResponse.size;
+    const displaySize = size === undefined
+        ? 'unknown'
+        : size >= 1024 * 1024
+            ? `${(size / (1024 * 1024)).toFixed(2)} MB`
+            : size >= 1024
+                ? `${(size / 1024).toFixed(2)} KB`
+                : `${size} bytes`;
+    info(`Artifact ${artifactName} has been successfully uploaded! Final size is ${displaySize}. Artifact ID is ${uploadResponse.id}`);
     setOutput('artifact-id', uploadResponse.id);
     setOutput('artifact-digest', uploadResponse.digest);
     const repository = github_context.repo;

--- a/src/shared/upload-artifact.ts
+++ b/src/shared/upload-artifact.ts
@@ -15,8 +15,17 @@ export async function uploadArtifact(
     options
   )
 
+  const size = uploadResponse.size
+  const displaySize =
+    size === undefined
+      ? 'unknown'
+      : size >= 1024 * 1024
+        ? `${(size / (1024 * 1024)).toFixed(2)} MB`
+        : size >= 1024
+          ? `${(size / 1024).toFixed(2)} KB`
+          : `${size} bytes`
   core.info(
-    `Artifact ${artifactName} has been successfully uploaded! Final size is ${uploadResponse.size} bytes. Artifact ID is ${uploadResponse.id}`
+    `Artifact ${artifactName} has been successfully uploaded! Final size is ${displaySize}. Artifact ID is ${uploadResponse.id}`
   )
   core.setOutput('artifact-id', uploadResponse.id)
   core.setOutput('artifact-digest', uploadResponse.digest)


### PR DESCRIPTION
## Summary
- Formats the artifact upload size log message to display in KB or MB instead of raw bytes
- Falls back to "unknown" if size is undefined (type system says it could be undefined)
