### PR TITLE
Properly document the `archive` input.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,13 +142,12 @@ You are welcome to still raise bugs in this repo.
     # enabled this to avoid uploading sensitive information.
     # Optional. Default is 'false'
     include-hidden-files:
-    
     # Whether to archive files before uploading.
     # When set to 'true', the artifact will be archived (.zip format) before uploading.
-    # When set to 'false, the artifact will be uploaded as-is without archiving.
+    # When set to 'false', the artifact will be uploaded as-is without archiving.
     # Notes when set to 'false':
     #   Only individual files can be uploaded without archiving.
-    #   The action will fail when the specified glob patterns resolve to multiple files. 
+    #   The action will fail when the specified glob patterns resolve to multiple files.
     #   The name of the file is used as the artifact name (the 'name' input is ignored).
     # Optional. Default is 'true'
     archive:
@@ -237,7 +236,7 @@ As of `v7`, an artifact can be uploaded without first being compressed into a .z
     archive: false
 ```
 
-This feature only supports uploading a single file. The action will fail when the specified glob patterns matching multiple files.
+This feature only supports uploading a single file. The action will fail if the specified glob patterns match multiple files.
 
 ### Altering compressions level (speed v. size)
 
@@ -503,7 +502,7 @@ You may also be limited by Artifacts if you have exceeded your shared storage qu
 
 When an Artifact is uploaded, all the files are assembled into an immutable Zip archive by default. There is currently no way to download individual artifact contents.
 
-The [exception to this rule](#Upload without archiving (zipping)) is when the `archive` input is set to `false`. This prevents files from being compressed prior to uploading, but only single files are supported at this time.
+The [exception to this rule](#upload-without-archiving-zipping) is when the `archive` input is set to `false`. This prevents files from being compressed prior to uploading, but only single files are supported at this time.
 
 ### Permission Loss
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,16 @@ You are welcome to still raise bugs in this repo.
     # enabled this to avoid uploading sensitive information.
     # Optional. Default is 'false'
     include-hidden-files:
+    
+    # Whether to archive files before uploading.
+    # When set to 'true', the artifact will be archived (.zip format) before uploading.
+    # When set to 'false, the artifact will be uploaded as-is without archiving.
+    # Notes when set to 'false':
+    #   Only individual files can be uploaded without archiving.
+    #   The action will fail when the specified glob patterns resolve to multiple files. 
+    #   The name of the file is used as the artifact name (the 'name' input is ignored).
+    # Optional. Default is 'true'
+    archive:
 ```
 
 ### Outputs
@@ -215,6 +225,19 @@ would be flattened and uploaded as =>
 If multiple paths are provided as input, the least common ancestor of all the search paths will be used as the root directory of the artifact. Exclude paths do not affect the directory structure.
 
 Relative and absolute file paths are both allowed. Relative paths are rooted against the current working directory. Paths that begin with a wildcard character should be quoted to avoid being interpreted as YAML aliases.
+
+### Upload without archiving (zipping)
+
+As of `v7`, an artifact can be uploaded without first being compressed into a .zip file.
+
+```yaml
+- uses: actions/upload-artifact@v7
+  with:
+    path: generated-changelog.md
+    archive: false
+```
+
+This feature only supports uploading a single file. The action will fail when the specified glob patterns matching multiple files.
 
 ### Altering compressions level (speed v. size)
 
@@ -478,7 +501,9 @@ You may also be limited by Artifacts if you have exceeded your shared storage qu
 
 ### Zip archives
 
-When an Artifact is uploaded, all the files are assembled into an immutable Zip archive. There is currently no way to download artifacts in a format other than a Zip or to download individual artifact contents.
+When an Artifact is uploaded, all the files are assembled into an immutable Zip archive by default. There is currently no way to download individual artifact contents.
+
+The [exception to this rule](#Upload without archiving (zipping)) is when the `archive` input is set to `false`. This prevents files from being compressed prior to uploading, but only single files are supported at this time.
 
 ### Permission Loss
 


### PR DESCRIPTION
This updates the README.md file to properly document the `archive` input added in [v7.0.0](https://github.com/actions/upload-artifact/releases/tag/v7.0.0).