### PR TITLE
docs: clarify retention-days minimum

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ You are welcome to still raise bugs in this repo.
     if-no-files-found:
 
     # Duration after which artifact will expire in days. 0 means using default retention.
-    # Minimum 1 day.
+    # Minimum 0 days when using repository defaults, otherwise 1 day.
     # Maximum 90 days unless changed from the repository settings page.
     # Optional. Defaults to repository settings.
     retention-days:


### PR DESCRIPTION
## Summary

- clarify the `retention-days` comment so it matches the documented `0 means use repository defaults` behavior

## Testing

- verified the updated wording now distinguishes between the repository-default `0` case and the explicit non-zero minimum

Closes #738
